### PR TITLE
Disable caching features in firebase.json for specific routes

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -11,6 +11,44 @@
         "source": "**",
         "destination": "/index.html"
       }
+    ],
+    "headers": [
+      {
+        "source": "/",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache"
+          }
+        ]
+      },
+      {
+        "source": "/sw.js",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache"
+          }
+        ]
+      },
+      {
+        "source": "/index.html",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache"
+          }
+        ]
+      },
+      {
+        "source": "/manifest.webmanifest",
+        "headers": [
+          {
+            "key": "Cache-Control",
+            "value": "no-cache"
+          }
+        ]
+      }
     ]
   }
 }


### PR DESCRIPTION
Disable caching features in `firebase.json` for specific routes.

* Add a `headers` section to the `hosting` object in `firebase.json`.
* Set `Cache-Control` to `no-cache` for the routes `/`, `/sw.js`, `/index.html`, and `/manifest.webmanifest`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/MiguelRipoll23/tus-santander/pull/375?shareId=844c87c1-806d-4dc3-8bda-277ec52fd6a1).