### PR TITLE
Fix markers list initialization in MapView

### DIFF
--- a/src/utils/MarkerUtils.jsx
+++ b/src/utils/MarkerUtils.jsx
@@ -1,0 +1,13 @@
+import Stops from "../json/stops.min.json";
+
+// Precompute markers from static Stops data
+const markers = Object.keys(Stops).map((key) => {
+  const [id, latitude, longitude, name] = Stops[key];
+  return {
+    id,
+    text: name,
+    position: { lat: latitude, lng: longitude },
+  };
+});
+
+export default markers;

--- a/src/views/map/MapView.jsx
+++ b/src/views/map/MapView.jsx
@@ -8,9 +8,7 @@ import Main from "../../components/Main.jsx";
 import Spinner from "../../components/Spinner.jsx";
 import ClosestMarkers from "../../components/map/ClosestMarkers.jsx";
 
-import Stops from "../../json/stops.min.json";
-
-const markers = [];
+import markers from "../../utils/MarkerUtils.jsx";
 
 const MapView = () => {
   const { getText } = useI18n();
@@ -23,7 +21,7 @@ const MapView = () => {
   const [center, setCenter] = useState(defaultCenter);
   const [closestMarkers, setClosestMarkers] = useState([]);
 
-  const getCurrentLocation = () => {
+  const getCurrentLocation = useCallback(() => {
     const successCallback = (position) => {
       setCenter({
         lat: position.coords.latitude,
@@ -39,24 +37,8 @@ const MapView = () => {
     };
 
     navigator.geolocation.getCurrentPosition(successCallback, errorCallback);
-  };
+  }, [getText]);
 
-  const getMarkers = () => {
-    for (let key in Stops) {
-      const [id, latitude, longitude, name] = Stops[key];
-
-      const marker = {
-        id: id,
-        text: name,
-        position: {
-          lat: latitude,
-          lng: longitude,
-        },
-      };
-
-      markers.push(marker);
-    }
-  };
 
   const mapOptions = {
     mapId: "map",
@@ -112,8 +94,7 @@ const MapView = () => {
   // Mount
   useEffect(() => {
     getCurrentLocation();
-    getMarkers();
-  }, []);
+  }, [getCurrentLocation]);
 
   return (
     <Fragment>


### PR DESCRIPTION
## Summary
- move stop markers computation to a dedicated util
- use the constant markers list inside `MapView`
- refactor `getCurrentLocation` to satisfy lint

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68680452c07083279addc8af3af7872c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved marker data handling by centralizing marker creation and importing pre-processed markers for map display.
  * Simplified and streamlined marker management within the map view.

* **Performance**
  * Enhanced efficiency by removing redundant marker processing and leveraging memoization for location functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->