### PR TITLE
Update telemetry rules for iOS >=18

### DIFF
--- a/src/views/estimations-stop/EstimationsStopView.jsx
+++ b/src/views/estimations-stop/EstimationsStopView.jsx
@@ -35,11 +35,14 @@ const EstimationsStopView = () => {
 
   const getTelemetryParams = () => {
     try {
-      const isAppleMobile = /iPhone/i.test(navigator.userAgent);
+      const ua = navigator.userAgent;
+      const isIphone = /iPhone/i.test(ua);
+      const versionMatch = /OS (\d+)_/i.exec(ua);
+      const iosVersion = versionMatch ? parseInt(versionMatch[1], 10) : 0;
+
+      if (!isIphone || iosVersion < 18) return "";
+
       const isStandalone = window.navigator.standalone === true;
-
-      if (!isAppleMobile || !isStandalone) return "";
-
       const screenWidth = window.screen?.width || 0;
       const screenHeight = window.screen?.height || 0;
 


### PR DESCRIPTION
## Summary
- only send telemetry parameters when the device is an iPhone running iOS 18 or higher

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react')*

------
https://chatgpt.com/codex/tasks/task_e_686d4ef4a564832792185545bd0cf5d9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of iPhone devices and their iOS version for telemetry, ensuring more accurate data collection and compatibility checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->