### PR TITLE
Implement telemetry identifier and send on iPhone load

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -1,8 +1,14 @@
+import { useEffect } from "react";
 import { ViewProvider } from "../providers/ViewProvider.jsx";
 import { I18nProvider } from "../providers/I18nProvider.jsx";
 import View from "./View.jsx";
+import { sendTelemetry } from "../utils/TelemetryUtils.jsx";
 
 const App = () => {
+  useEffect(() => {
+    sendTelemetry();
+  }, []);
+
   return (
     <I18nProvider>
       <ViewProvider>

--- a/src/utils/ApiConstants.jsx
+++ b/src/utils/ApiConstants.jsx
@@ -2,3 +2,4 @@ export const GOOGLE_MAPS_KEY = import.meta.env.VITE_APP_GOOGLE_MAPS_KEY;
 export const API_HOST = import.meta.env.VITE_APP_API_HOST;
 export const API_PATH_JSON_ESTIMATIONS = "/v4/estimations";
 export const API_PATH_JSON_ROUTE = "/v4/route";
+export const API_PATH_JSON_TELEMETRY = "/v4/telemetry";

--- a/src/utils/TelemetryUtils.jsx
+++ b/src/utils/TelemetryUtils.jsx
@@ -1,0 +1,39 @@
+import { API_HOST, API_PATH_JSON_TELEMETRY } from "./ApiConstants.jsx";
+import { getFavorites } from "./FavoriteUtils.jsx";
+
+export const getUserIdentifier = () => {
+  let identifier = localStorage.getItem("user_identifier");
+  if (!identifier) {
+    const bytes = crypto.getRandomValues(new Uint8Array(16));
+    identifier = Array.from(bytes)
+      .map((b) => b.toString(16).padStart(2, "0"))
+      .join("");
+    localStorage.setItem("user_identifier", identifier);
+  }
+  return identifier;
+};
+
+export const sendTelemetry = async () => {
+  if (typeof navigator === "undefined" || /iPhone/i.test(navigator.userAgent) === false) {
+    return;
+  }
+
+  const favorites = getFavorites().map((f) => f.stop_name);
+
+  const data = {
+    userIdentifier: getUserIdentifier(),
+    userAgent: navigator.userAgent,
+    screenWidth: screen.width,
+    screenHeight: screen.height,
+    favorites,
+  };
+
+  try {
+    await fetch(API_HOST + API_PATH_JSON_TELEMETRY, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(data),
+      keepalive: true,
+    });
+  } catch (_) {}
+};


### PR DESCRIPTION
## Summary
- add API constant for telemetry
- generate and persist a user identifier in localStorage
- send telemetry data on iPhone devices

## Testing
- `npm run lint` *(fails: Cannot find package 'eslint-plugin-react')*

------
https://chatgpt.com/codex/tasks/task_e_686d56fb4b308327ae95bf8652886b78

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced telemetry reporting, which collects anonymous usage data on iPhone devices to help improve the app experience.
  * Added a persistent, anonymous user identifier for telemetry purposes.

* **Chores**
  * Added a dedicated telemetry API endpoint for future use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->