### PR TITLE
Implement telemetry identifier and send on iPhone load

### DIFF
--- a/src/components/App.jsx
+++ b/src/components/App.jsx
@@ -1,8 +1,14 @@
+import { useEffect } from "react";
 import { ViewProvider } from "../providers/ViewProvider.jsx";
 import { I18nProvider } from "../providers/I18nProvider.jsx";
 import View from "./View.jsx";
+import { sendTelemetry } from "../utils/TelemetryUtils.jsx";
 
 const App = () => {
+  useEffect(() => {
+    sendTelemetry();
+  }, []);
+
   return (
     <I18nProvider>
       <ViewProvider>

--- a/src/utils/ApiConstants.jsx
+++ b/src/utils/ApiConstants.jsx
@@ -2,3 +2,4 @@ export const GOOGLE_MAPS_KEY = import.meta.env.VITE_APP_GOOGLE_MAPS_KEY;
 export const API_HOST = import.meta.env.VITE_APP_API_HOST;
 export const API_PATH_JSON_ESTIMATIONS = "/v4/estimations";
 export const API_PATH_JSON_ROUTE = "/v4/route";
+export const API_PATH_JSON_TELEMETRY = "/v4/telemetry";

--- a/src/utils/TelemetryUtils.jsx
+++ b/src/utils/TelemetryUtils.jsx
@@ -1,0 +1,36 @@
+import { API_HOST, API_PATH_JSON_TELEMETRY } from "./ApiConstants.jsx";
+import { getFavorites } from "./FavoriteUtils.jsx";
+
+export const USER_IDENTIFIER_KEY = "user_identifier";
+
+export const getUserIdentifier = () => {
+  let identifier = localStorage.getItem(USER_IDENTIFIER_KEY);
+  if (!identifier) {
+    identifier = crypto.randomUUID();
+    localStorage.setItem(USER_IDENTIFIER_KEY, identifier);
+  }
+  return identifier;
+};
+
+export const sendTelemetry = () => {
+  if (typeof navigator === "undefined" || !/iPhone/i.test(navigator.userAgent)) {
+    return;
+  }
+
+  const favorites = getFavorites().map((f) => f.stop_name);
+
+  const data = {
+    userIdentifier: getUserIdentifier(),
+    userAgent: navigator.userAgent,
+    screenWidth: screen.width,
+    screenHeight: screen.height,
+    favorites,
+  };
+
+  fetch(API_HOST + API_PATH_JSON_TELEMETRY, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(data),
+    keepalive: true,
+  }).catch(() => {});
+};


### PR DESCRIPTION
## Summary
- add API constant for telemetry
- generate and persist a user identifier in localStorage using `crypto.randomUUID`
- send telemetry data on iPhone devices on app load

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_686d56fb4b308327ae95bf8652886b78

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced telemetry reporting that collects and sends anonymized usage data from iPhone browsers when the app loads.
  * Added a persistent user identifier to help track unique app usage (without personal information).

* **Chores**
  * Added a dedicated API endpoint for telemetry data collection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->