### PR TITLE
Remove telemetry params from stop view

### DIFF
--- a/src/views/estimations-stop/EstimationsStopView.jsx
+++ b/src/views/estimations-stop/EstimationsStopView.jsx
@@ -33,37 +33,13 @@ const EstimationsStopView = () => {
   const [lines, setLines] = useState([]);
   const [estimations, setEstimations] = useState([]);
 
-  const getTelemetryParams = () => {
-    try {
-      const ua = navigator.userAgent;
-      const isIphone = /iPhone/i.test(ua);
-      const versionMatch = /OS (\d+)_/i.exec(ua);
-      const iosVersion = versionMatch ? parseInt(versionMatch[1], 10) : 0;
-
-      if (!isIphone || iosVersion < 18) return "";
-
-      const isStandalone = window.navigator.standalone === true;
-      const screenWidth = window.screen?.width || 0;
-      const screenHeight = window.screen?.height || 0;
-
-      return (
-        `&standalone=${isStandalone}` +
-        `&screenWidth=${screenWidth}` +
-        `&screenHeight=${screenHeight}`
-      );
-    } catch (error) {
-      console.warn("Failed to get telemetry params:", error);
-      return "";
-    }
-  };
-
   const getEstimations = useCallback(
     async (update = false) => {
       // Reset
       setError(false);
       setEstimations([]);
 
-      let query = `?stopId=${stopId}` + getTelemetryParams();
+      let query = `?stopId=${stopId}`;
 
       if (update) {
         query += "&update=true";


### PR DESCRIPTION
## Summary
- remove query telemetry params from EstimationsStopView
- keep telemetry reporting via `/v4/telemetry`

## Testing
- `npm run lint` *(fails: cannot find module 'eslint-plugin-react')*
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686d611ca43083278bf8980521fc4bac

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Removed iPhone-specific telemetry parameters from API requests for stop estimations. Only essential parameters are now included.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->