### PR TITLE
Migrate to iOS 26 styles

### DIFF
--- a/src/components/HeartIcon.jsx
+++ b/src/components/HeartIcon.jsx
@@ -5,7 +5,7 @@ const HeartIcon = (props) => {
   const { getText } = useI18n();
   return (
     <button
-      className={styles.HeartIcon}
+      className={`${styles.HeartIcon} liquid-glass`}
       aria-label={getText("add_to_favorites")}
       data-state={props.heartState > 1 ? "" : ""}
       onClick={props.updateFavorite}

--- a/src/components/HeartIcon.module.css
+++ b/src/components/HeartIcon.module.css
@@ -10,7 +10,6 @@
   padding-right: 8px;
   padding-top: 9px;
   padding-bottom: 7px;
-  background-color: rgba(0, 112, 240, 0.1);
   animation: fade-in 0.2s;
 
   &::after {

--- a/src/components/HeartIcon.module.css
+++ b/src/components/HeartIcon.module.css
@@ -10,6 +10,7 @@
   padding-right: 8px;
   padding-top: 9px;
   padding-bottom: 7px;
+  background-color: rgba(0, 112, 240, 0.1);
   animation: fade-in 0.2s;
 
   &::after {

--- a/src/components/HeartIcon.module.css
+++ b/src/components/HeartIcon.module.css
@@ -2,11 +2,14 @@
   margin: 11px var(--margin-lr);
   font-family: icons;
   font-size: 24px;
-  color: #000;
+  color: #ff2d55;
   line-height: 24px;
   position: relative;
   top: -1px;
-  padding: 8px;
+  padding-left: 8px;
+  padding-right: 8px;
+  padding-top: 9px;
+  padding-bottom: 7px;
   animation: fade-in 0.2s;
 
   &::after {

--- a/src/components/HeartIcon.module.css
+++ b/src/components/HeartIcon.module.css
@@ -2,7 +2,7 @@
   margin: 11px var(--margin-lr);
   font-family: icons;
   font-size: 24px;
-  color: #ff2d55;
+  color: #000;
   line-height: 24px;
   position: relative;
   top: -1px;

--- a/src/components/HeartIcon.module.css
+++ b/src/components/HeartIcon.module.css
@@ -11,6 +11,7 @@
   padding-top: 9px;
   padding-bottom: 7px;
   animation: fade-in 0.2s;
+  box-shadow: none;
 
   &::after {
     content: attr(data-state);

--- a/src/components/HeartIcon.module.css
+++ b/src/components/HeartIcon.module.css
@@ -1,13 +1,12 @@
 .HeartIcon {
-  padding: 11px var(--margin-lr);
+  margin: 11px var(--margin-lr);
   font-family: icons;
   font-size: 24px;
   color: #ff2d55;
   line-height: 24px;
   position: relative;
   top: -1px;
-  padding-top: 14px;
-  padding-bottom: 8px;
+  padding: 8px;
   animation: fade-in 0.2s;
 
   &::after {

--- a/src/components/Main.jsx
+++ b/src/components/Main.jsx
@@ -1,10 +1,11 @@
 import styles from "./Main.module.css";
 
 const Main = (props) => {
+  const paddingTop = props.paddingTop ?? "0";
   const paddingBottom = props.paddingBottom ?? "0";
 
   return (
-    <main className={styles.Content} style={{ paddingBottom }}>
+    <main className={styles.Content} style={{ paddingTop, paddingBottom }}>
       {props.children}
     </main>
   );

--- a/src/components/Main.module.css
+++ b/src/components/Main.module.css
@@ -1,5 +1,4 @@
 .Content {
-  padding-top: 64px;
   flex: 1;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;

--- a/src/components/Main.module.css
+++ b/src/components/Main.module.css
@@ -1,4 +1,5 @@
 .Content {
+  padding-top: 64px;
   flex: 1;
   overflow-y: auto;
   -webkit-overflow-scrolling: touch;

--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -1,37 +1,11 @@
 import { Fragment, useEffect, useState } from "react";
 import Header from "./Header.jsx";
-import { useI18n } from "../contexts/I18nContext.jsx";
-
 import styles from "./Nav.module.css";
 
 const Nav = (props) => {
-  const { getText } = useI18n();
-  const [borderOpacity, setBorderOpacity] = useState(0);
-
   const goBack = () => {
     window.history.back();
   };
-
-  useEffect(() => {
-    const mainElement = document.getElementsByTagName("main")[0];
-
-    const handleScroll = () => {
-      let opacity = 0;
-      let scrollY = mainElement.scrollTop;
-
-      if (scrollY > 50) {
-        opacity = 0.15;
-      } else {
-        opacity = (scrollY * 0.15) / 50;
-      }
-
-      setBorderOpacity(opacity);
-    };
-
-    mainElement.addEventListener("scroll", handleScroll, { passive: true });
-
-    return () => mainElement.removeEventListener("scroll", handleScroll);
-  });
 
   return (
     <Fragment>
@@ -39,18 +13,19 @@ const Nav = (props) => {
         <Header text={props.titleText}>{props.children}</Header>
       )}
       {props.isHeader === false && (
-        <div
-          className={styles.Nav}
-          style={{ "--border-opacity": borderOpacity }}
-        >
+        <div className={styles.Nav}>
           <div className={styles.NavLeft}>
-            <button className={styles.BackButton} onClick={goBack}>
+            <button
+              className={`${styles.BackButton} liquid-glass`}
+              onClick={goBack}
+            >
               <span className={styles.BackIcon}></span>
-              <span>{getText("back")}</span>
             </button>
           </div>
           <div className={styles.NavCenter}>
-            <span className={styles.NavTitle}>{props.titleText}</span>
+            <span className={`${styles.NavTitle} liquid-glass`}>
+              {props.titleText}
+            </span>
           </div>
           <div className={styles.NavRight}>{props.children}</div>
         </div>

--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -17,9 +17,12 @@ const Nav = (props) => {
           <div className={styles.NavLeft}>
             <button
               className={`${styles.BackButton} liquid-glass`}
+              aria-label="Back"
               onClick={goBack}
             >
-              <span className={styles.BackIcon}></span>
+              <span className={styles.BackIcon} aria-hidden="true">
+                
+              </span>
             </button>
           </div>
           <div className={styles.NavCenter}>

--- a/src/components/Nav.module.css
+++ b/src/components/Nav.module.css
@@ -33,7 +33,7 @@
 .BackButton {
   font-size: 15px;
   line-height: 24px;
-  color: #000;
+  color: var(--color-blue);
   overflow: hidden;
   white-space: nowrap;
   padding: 8px;
@@ -41,7 +41,7 @@
   animation: fade-in 0.2s;
 
   @media (prefers-color-scheme: dark) {
-    background: #FFF;
+    background: #fff;
     border-top: none;
   }
 }

--- a/src/components/Nav.module.css
+++ b/src/components/Nav.module.css
@@ -38,6 +38,7 @@
   white-space: nowrap;
   padding: 8px;
   margin: 11px var(--margin-lr);
+  background-color: rgba(0, 112, 240, 0.1);
   animation: fade-in 0.2s;
 
   @media (prefers-color-scheme: dark) {
@@ -59,4 +60,5 @@
   font-weight: 700;
   margin: auto;
   padding: 4px 12px;
+  background-color: rgba(0, 112, 240, 0.1);
 }

--- a/src/components/Nav.module.css
+++ b/src/components/Nav.module.css
@@ -1,14 +1,9 @@
 .Nav {
+  position: fixed;
+  width: 100%;
   display: flex;
   min-height: 55px;
   align-items: center;
-  border-bottom-width: 1px;
-  border-bottom-style: solid;
-  border-bottom-color: rgba(0, 0, 0, var(--border-opacity));
-
-  @media (prefers-color-scheme: dark) {
-    border-bottom-color: rgba(255, 255, 255, var(--border-opacity));
-  }
 }
 
 .NavLeft {
@@ -37,11 +32,11 @@
 .BackButton {
   font-size: 15px;
   line-height: 24px;
-  color: var(--color-blue);
+  color: #000;
   overflow: hidden;
   white-space: nowrap;
-  text-overflow: ellipsis;
-  padding: 11px var(--margin-lr);
+  padding: 8px;
+  margin: 11px var(--margin-lr);
   animation: fade-in 0.2s;
 }
 
@@ -55,9 +50,8 @@
 }
 
 .NavTitle {
-  padding: 14px 0;
   font-size: 15px;
   font-weight: 700;
-  text-align: center;
-  width: 100%;
+  margin: auto;
+  padding: 4px 12px;
 }

--- a/src/components/Nav.module.css
+++ b/src/components/Nav.module.css
@@ -33,7 +33,7 @@
 .BackButton {
   font-size: 15px;
   line-height: 24px;
-  color: var(--color-blue);
+  color: #000;
   overflow: hidden;
   white-space: nowrap;
   padding: 8px;
@@ -41,8 +41,7 @@
   animation: fade-in 0.2s;
 
   @media (prefers-color-scheme: dark) {
-    background: #fff;
-    border-top: none;
+    color: #fff;
   }
 }
 

--- a/src/components/Nav.module.css
+++ b/src/components/Nav.module.css
@@ -39,6 +39,7 @@
   padding: 8px;
   margin: 11px var(--margin-lr);
   animation: fade-in 0.2s;
+  box-shadow: none;
 
   @media (prefers-color-scheme: dark) {
     color: #fff;
@@ -59,4 +60,5 @@
   font-weight: 700;
   margin: auto;
   padding: 4px 12px;
+  box-shadow: none;
 }

--- a/src/components/Nav.module.css
+++ b/src/components/Nav.module.css
@@ -38,7 +38,6 @@
   white-space: nowrap;
   padding: 8px;
   margin: 11px var(--margin-lr);
-  background-color: rgba(0, 112, 240, 0.1);
   animation: fade-in 0.2s;
 
   @media (prefers-color-scheme: dark) {
@@ -60,5 +59,4 @@
   font-weight: 700;
   margin: auto;
   padding: 4px 12px;
-  background-color: rgba(0, 112, 240, 0.1);
 }

--- a/src/components/Nav.module.css
+++ b/src/components/Nav.module.css
@@ -4,6 +4,7 @@
   display: flex;
   min-height: 55px;
   align-items: center;
+  z-index: 1;
 }
 
 .NavLeft {

--- a/src/components/Nav.module.css
+++ b/src/components/Nav.module.css
@@ -39,6 +39,11 @@
   padding: 8px;
   margin: 11px var(--margin-lr);
   animation: fade-in 0.2s;
+
+  @media (prefers-color-scheme: dark) {
+    background: #FFF;
+    border-top: none;
+  }
 }
 
 .BackIcon {

--- a/src/components/RefreshIcon.jsx
+++ b/src/components/RefreshIcon.jsx
@@ -3,7 +3,7 @@ import styles from "./RefreshIcon.module.css";
 const RefreshIcon = (props) => {
   return (
     <button
-      className={styles.RefreshIcon}
+      className={`${styles.RefreshIcon} liquid-glass`}
       aria-label="Refrescar"
       onClick={props.refreshContent}
     >

--- a/src/components/RefreshIcon.module.css
+++ b/src/components/RefreshIcon.module.css
@@ -11,7 +11,7 @@
   animation: fade-in 0.2s;
   line-height: 74px;
   bottom: 28px;
-  background: rgba(0, 112, 240, 0.6);
+  background-color: rgba(0, 112, 240, 0.6);
   color: #fff;
 
   span {

--- a/src/components/RefreshIcon.module.css
+++ b/src/components/RefreshIcon.module.css
@@ -11,10 +11,8 @@
   animation: fade-in 0.2s;
   line-height: 74px;
   bottom: 28px;
-
-  @media (prefers-color-scheme: dark) {
-    color: #fff;
-  }
+  background: rgba(0, 112, 240, 0.6);
+  color: #fff;
 
   span {
     position: relative;

--- a/src/components/RefreshIcon.module.css
+++ b/src/components/RefreshIcon.module.css
@@ -1,9 +1,7 @@
 .RefreshIcon {
   font-family: icons;
   font-size: 34px;
-  color: #fff;
-  background: var(--color-light-blue);
-  box-shadow: 0 2px 12px rgba(0, 0, 0, 0.2);
+  color: #000;
   position: fixed;
   border-radius: 100%;
   width: 74px;
@@ -13,6 +11,10 @@
   animation: fade-in 0.2s;
   line-height: 74px;
   bottom: 28px;
+
+  @media (prefers-color-scheme: dark) {
+    color: #fff;
+  }
 
   span {
     position: relative;

--- a/src/components/View.module.css
+++ b/src/components/View.module.css
@@ -1,5 +1,3 @@
 .SelectedView {
-  display: flex;
-  flex-direction: column;
   height: 100%;
 }

--- a/src/components/home/HomeMenu.jsx
+++ b/src/components/home/HomeMenu.jsx
@@ -35,7 +35,7 @@ const HomeMenu = () => {
   const menuItems = menuItemsData(getText, setSubViewId, setViewId);
 
   return (
-    <div className={styles.homeMenu}>
+    <div className={`${styles.homeMenu} liquid-glass`}>
       {menuItems.map(({ id, icon, label, onClick }) => (
         <div
           key={id}

--- a/src/components/home/HomeMenu.module.css
+++ b/src/components/home/HomeMenu.module.css
@@ -18,7 +18,6 @@
 }
 
 .item {
-  float: left;
   text-align: center;
   flex: 1;
   cursor: pointer;
@@ -30,7 +29,7 @@
 
   &[data-selected="true"] {
     color: var(--color-blue);
-    background-color: rgba(0, 0, 0, 0.1);
+    background-color: rgba(0, 112, 240, 0.1);
     backdrop-filter: blur(20px) saturate(180%);
     opacity: 1;
   }

--- a/src/components/home/HomeMenu.module.css
+++ b/src/components/home/HomeMenu.module.css
@@ -1,8 +1,10 @@
 .homeMenu {
+  border-radius: 50px;
+  padding: 0 15px;
   align-items: center;
   display: flex;
   position: fixed;
-  width: 300px; /* Keep current width */
+  width: 300px;
   left: 0;
   right: 0;
   margin-left: auto;

--- a/src/components/home/HomeMenu.module.css
+++ b/src/components/home/HomeMenu.module.css
@@ -3,12 +3,9 @@
   align-items: center;
   display: flex;
   position: fixed;
-  left: 0;
-  right: 0;
   bottom: calc(env(safe-area-inset-bottom) + 28px);
-  max-width: 310px;
-  margin-left: auto;
-  margin-right: auto;
+  left: 50%;
+  transform: translateX(-50%);
   z-index: 9;
 
   @media (prefers-color-scheme: dark) {

--- a/src/components/home/HomeMenu.module.css
+++ b/src/components/home/HomeMenu.module.css
@@ -1,15 +1,14 @@
 .homeMenu {
   border-radius: 50px;
-  padding: 0 15px;
   align-items: center;
   display: flex;
   position: fixed;
-  width: 300px;
   left: 0;
   right: 0;
+  bottom: calc(env(safe-area-inset-bottom) + 28px);
+  max-width: 310px;
   margin-left: auto;
   margin-right: auto;
-  bottom: calc(var(--margin-lr) + env(safe-area-inset-bottom));
   z-index: 9;
 
   @media (prefers-color-scheme: dark) {
@@ -20,19 +19,25 @@
 
 .item {
   float: left;
-  width: 100px;
   text-align: center;
   flex: 1;
   cursor: pointer;
-  padding: 14px 0;
+  border-radius: 50px;
+  margin: 4px;
+  padding: 6px 24px;
   color: #000;
+  transition: color 0.2s ease-in-out, background-color 0.2s ease-in-out;
 
   &[data-selected="true"] {
     color: var(--color-blue);
+    background-color: rgba(0, 0, 0, 0.1);
+    backdrop-filter: blur(20px) saturate(180%);
+    opacity: 1;
   }
 
   @media (prefers-color-scheme: dark) {
     color: rgba(255, 255, 255, 0.55);
+    opacity: 0.6;
   }
 }
 

--- a/src/components/home/HomeMenu.module.css
+++ b/src/components/home/HomeMenu.module.css
@@ -1,11 +1,13 @@
 .homeMenu {
-  background: #f7f7f7;
-  border-top: 1px solid rgba(0, 0, 0, 0.15);
   align-items: center;
   display: flex;
   position: fixed;
-  bottom: 0;
-  width: 100%;
+  width: 300px; /* Keep current width */
+  left: 0;
+  right: 0;
+  margin-left: auto;
+  margin-right: auto;
+  bottom: calc(var(--margin-lr) + env(safe-area-inset-bottom));
   z-index: 9;
 
   @media (prefers-color-scheme: dark) {
@@ -20,9 +22,8 @@
   text-align: center;
   flex: 1;
   cursor: pointer;
-  padding-top: 14px;
-  padding-bottom: calc(28px + env(safe-area-inset-bottom));
-  color: rgba(0, 0, 0, 0.55);
+  padding: 14px 0;
+  color: #000;
 
   &[data-selected="true"] {
     color: var(--color-blue);

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -1,5 +1,4 @@
 {
-  "back": "Back",
   "favorites": "Favorites",
   "map": "Map",
   "search": "Search",

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -1,5 +1,4 @@
 {
-  "back": "Atrás",
   "favorites": "Favoritos",
   "map": "Mapa",
   "search": "Buscar",

--- a/src/index.css
+++ b/src/index.css
@@ -44,7 +44,6 @@ button {
   border-radius: 24px;
   border: 1px solid rgba(255, 255, 255, 0.3);
   background-color: rgba(255, 255, 255, 0.1);
-  box-shadow: 0 0px 12px rgba(0, 0, 0, 0.05);
 }
 
 *[draggable="true"] {

--- a/src/index.css
+++ b/src/index.css
@@ -43,8 +43,8 @@ button {
   -webkit-backdrop-filter: blur(20px) saturate(180%);
   border-radius: 24px;
   border: 1px solid rgba(255, 255, 255, 0.3);
-  box-shadow: 0 2px 18px rgba(31, 38, 135, 0.1);
-  background: rgba(255, 255, 255, 0.4);
+  background-color: rgba(255, 255, 255, 0.1);
+  box-shadow: 0 0px 60px rgba(0, 0, 0, 0.14);
 }
 
 *[draggable="true"] {

--- a/src/index.css
+++ b/src/index.css
@@ -44,7 +44,7 @@ button {
   border-radius: 24px;
   border: 1px solid rgba(255, 255, 255, 0.3);
   background-color: rgba(255, 255, 255, 0.1);
-  box-shadow: 0 0px 60px rgba(0, 0, 0, 0.14);
+  box-shadow: 0 0px 12px rgba(0, 0, 0, 0.04);
 }
 
 *[draggable="true"] {

--- a/src/index.css
+++ b/src/index.css
@@ -44,6 +44,7 @@ button {
   border-radius: 24px;
   border: 1px solid rgba(255, 255, 255, 0.3);
   background-color: rgba(255, 255, 255, 0.1);
+  box-shadow: 0 0px 12px rgba(0, 0, 0, 0.05);
 }
 
 *[draggable="true"] {

--- a/src/index.css
+++ b/src/index.css
@@ -44,7 +44,7 @@ button {
   border-radius: 24px;
   border: 1px solid rgba(255, 255, 255, 0.3);
   background-color: rgba(255, 255, 255, 0.1);
-  box-shadow: 0 0px 12px rgba(0, 0, 0, 0.04);
+  box-shadow: 0 0px 12px rgba(0, 0, 0, 0.05);
 }
 
 *[draggable="true"] {

--- a/src/index.css
+++ b/src/index.css
@@ -43,7 +43,7 @@ button {
   -webkit-backdrop-filter: blur(20px) saturate(180%);
   border-radius: 24px;
   border: 1px solid rgba(255, 255, 255, 0.3);
-  box-shadow: 0 2px 18px rgba(31, 38, 135, 0.07);
+  box-shadow: 0 2px 18px rgba(31, 38, 135, 0.1);
   background: rgba(255, 255, 255, 0.4);
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -43,7 +43,7 @@ button {
   -webkit-backdrop-filter: blur(20px) saturate(180%);
   border-radius: 24px;
   border: 1px solid rgba(255, 255, 255, 0.3);
-  box-shadow: 0 2px 18px rgba(31, 38, 135, 0.15);
+  box-shadow: 0 2px 18px rgba(31, 38, 135, 0.07);
   background: rgba(255, 255, 255, 0.4);
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -39,12 +39,11 @@ button {
 }
 
 .liquid-glass {
-  background: rgba(255, 255, 255, 0.2); /* Lower opacity for more depth */
   backdrop-filter: blur(20px) saturate(180%);
   -webkit-backdrop-filter: blur(20px) saturate(180%);
   border-radius: 24px;
   border: 1px solid rgba(255, 255, 255, 0.3);
-  box-shadow: 0 8px 32px rgba(31, 38, 135, 0.37);
+  box-shadow: 0 2px 18px rgba(31, 38, 135, 0.15);
   background: rgba(255, 255, 255, 0.4);
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -38,14 +38,19 @@ button {
   padding: 0;
 }
 
+.liquid-glass {
+  background: rgba(255, 255, 255, 0.2); /* Lower opacity for more depth */
+  backdrop-filter: blur(20px) saturate(180%);
+  -webkit-backdrop-filter: blur(20px) saturate(180%);
+  border-radius: 24px;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  box-shadow: 0 8px 32px rgba(31, 38, 135, 0.37);
+  background: rgba(255, 255, 255, 0.4);
+}
+
 *[draggable="true"] {
   animation: wiggle 0.5s linear infinite;
   cursor: move;
-}
-
-#app {
-  display: flex;
-  flex-direction: column;
 }
 
 #time1[data-time="0"] {

--- a/src/views/estimations-line/EstimationsLineView.jsx
+++ b/src/views/estimations-line/EstimationsLineView.jsx
@@ -106,7 +106,7 @@ const EstimationsLineView = () => {
   return (
     <Fragment>
       <Nav isHeader={false} titleText={stopName} />
-      <Main>
+      <Main paddingTop="64px">
         {loading && <Spinner />}
         {error && (
           <Error

--- a/src/views/estimations-stop/EstimationsStopView.jsx
+++ b/src/views/estimations-stop/EstimationsStopView.jsx
@@ -147,7 +147,7 @@ const EstimationsStopView = () => {
           <HeartIcon heartState={heartState} updateFavorite={updateFavorite} />
         )}
       </Nav>
-      <Main paddingBottom="105px">
+      <Main paddingTop="64px" paddingBottom="105px">
         {loading && <Spinner />}
         {error && (
           <Error

--- a/src/views/route-line/RouteLineView.jsx
+++ b/src/views/route-line/RouteLineView.jsx
@@ -74,7 +74,7 @@ const RouteLineView = () => {
         isHeader={false}
         titleText={`${lineLabel} ${lineDestination.toUpperCase()}`}
       />
-      <Main>
+      <Main paddingTop="64px">
         {loading && <Spinner />}
         {error && (
           <Error


### PR DESCRIPTION
Staging deploy requested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Added a "liquid-glass" translucent effect to nav, heart, refresh, and home menu elements; updated spacing, radii, colors, and selected-item visuals; home menu repositioned and nav made fixed.
* **New Features**
  * Main content now supports configurable top padding; several views apply top padding.
* **Bug Fixes**
  * Simplified navigation visuals — removed scroll-based border opacity; back button now shows only the icon with an accessible label.
* **Chores**
  * Removed unused "back" localization keys.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->