### PR TITLE
Change default fallback language from Spanish to English in I18nProvider

### DIFF
--- a/src/providers/I18nProvider.jsx
+++ b/src/providers/I18nProvider.jsx
@@ -23,7 +23,7 @@ export const I18nProvider = ({ children }) => {
       return langPrefix;
     }
 
-    return "es"; // Default fallback
+    return "en"; // Default fallback
   })();
 
   const [language, setLanguage] = useState(browserLanguage);


### PR DESCRIPTION
Staging deploy requested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - The app now defaults to English when the browser’s language isn’t supported (previously defaulted to Spanish). Users with unsupported locales will see the interface in English on first load.
  - Existing exact and prefix language matching behavior remains unchanged; only the final fallback is updated.
  - No action required: users can still manually select their preferred language in settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->