### PR TITLE
Improve dark mode stop line visibility

### DIFF
--- a/src/components/StopLines.module.css
+++ b/src/components/StopLines.module.css
@@ -33,6 +33,7 @@
     &:disabled {
       background: #fff;
       color: #000;
+      opacity: 0.4;
     }
   }
 }


### PR DESCRIPTION
## Summary
- Increase opacity of inactive stop lines in dark mode for better readability.

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Nav.jsx unused vars)


------
https://chatgpt.com/codex/tasks/task_e_68bc2d887e408327966544225b7e08d9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Style
  - Adjusted the appearance of disabled items in dark mode to improve visibility. Disabled elements now appear more discernible without altering existing background and text colors.
  - Ensures a more consistent visual experience between light and dark modes for disabled states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->