### PR TITLE
feat: enable transparent iOS nav bar in PWA mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,10 @@
 <html dir="ltr" lang="es">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover"
+    />
     <title>TUS Santander - App</title>
     <style type="text/css">
       @font-face {

--- a/index.html
+++ b/index.html
@@ -26,17 +26,7 @@
     />
     <meta content="tus,santander,app,bus,iphone,aplicación" name="keywords" />
     <meta name="application-name" content="TUS" />
-    <meta name="color-scheme" content="light,dark" />
-    <meta
-      name="theme-color"
-      content="#ffffff"
-      media="(prefers-color-scheme: light)"
-    />
-    <meta
-      name="theme-color"
-      content="#000000"
-      media="(prefers-color-scheme: dark)"
-    />
+      <meta name="color-scheme" content="light,dark" />
     <link rel="apple-touch-icon" href="/images/apple-touch-icon.png" />
     <meta property="og:title" content="TUS Santander - App" />
     <meta property="og:type" content="website" />

--- a/public/index.html
+++ b/public/index.html
@@ -2,7 +2,10 @@
 <html dir="ltr" lang="es">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1, viewport-fit=cover"
+    />
     <title>TUS Santander - App</title>
     <style type="text/css">
       @font-face {
@@ -12,6 +15,12 @@
         font-weight: normal;
         font-style: normal;
         font-display: swap;
+      }
+
+      #app {
+        box-sizing: border-box;
+        padding: env(safe-area-inset-top) env(safe-area-inset-right) 0
+          env(safe-area-inset-left);
       }
     </style>
     <link href="https://tusestimaciones.web.app" rel="canonical" />

--- a/public/index.html
+++ b/public/index.html
@@ -36,16 +36,6 @@
     />
     <meta name="application-name" content="TUS" />
     <meta name="color-scheme" content="light,dark" />
-    <meta
-      name="theme-color"
-      content="#ffffff"
-      media="(prefers-color-scheme: light)"
-    />
-    <meta
-      name="theme-color"
-      content="#000000"
-      media="(prefers-color-scheme: dark)"
-    />
     <link rel="apple-touch-icon" href="/images/apple-touch-icon.png" />
     <meta property="og:title" content="TUS Santander - App" />
     <meta property="og:type" content="website" />

--- a/public/index.html
+++ b/public/index.html
@@ -16,11 +16,10 @@
         font-style: normal;
         font-display: swap;
       }
-
-      #app {
-        box-sizing: border-box;
-        padding: env(safe-area-inset-top) env(safe-area-inset-right) 0
-          env(safe-area-inset-left);
+      body {
+        min-height: 100vh;
+        padding-top: env(safe-area-inset-top);
+        padding-bottom: env(safe-area-inset-bottom);
       }
     </style>
     <link href="https://tusestimaciones.web.app" rel="canonical" />

--- a/src/components/Nav.jsx
+++ b/src/components/Nav.jsx
@@ -1,4 +1,4 @@
-import { Fragment, useEffect, useState } from "react";
+import { Fragment } from "react";
 import Header from "./Header.jsx";
 import styles from "./Nav.module.css";
 

--- a/src/index.css
+++ b/src/index.css
@@ -10,6 +10,12 @@ html,
   height: 100%;
 }
 
+#app {
+  box-sizing: border-box;
+  padding: env(safe-area-inset-top) env(safe-area-inset-right) 0
+    env(safe-area-inset-left);
+}
+
 body {
   margin: 0;
   color: #000;

--- a/src/index.css
+++ b/src/index.css
@@ -4,20 +4,16 @@
   --margin-lr: 14px;
 }
 
-body,
 html,
 #app {
   height: 100%;
 }
 
-#app {
-  box-sizing: border-box;
-  padding: env(safe-area-inset-top) env(safe-area-inset-right) 0
-    env(safe-area-inset-left);
-}
-
 body {
   margin: 0;
+  min-height: 100vh;
+  padding-top: env(safe-area-inset-top);
+  padding-bottom: env(safe-area-inset-bottom);
   color: #000;
   font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen",
     "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue",


### PR DESCRIPTION
## Summary
- allow full-viewport rendering on iOS by adding `viewport-fit=cover`
- apply safe-area padding to the app root so content stays within the notch margins
- fix lint by removing unused React hooks in `Nav`

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c6aca9a8208327837fd1b8a1d3d22f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added safe-area support so content respects device display cutouts and preserves full-height layout.

* **Style**
  * Global layout updated with min-height and responsive padding to honor system insets.

* **Behavior**
  * Removed theme-color meta tags for light/dark themes (may change browser UI coloring).

* **Refactor**
  * Removed unused React hook imports with no functional impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->