### PR TITLE
Update viewport meta tags for PWA full screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,15 @@
 <html dir="ltr" lang="es">
   <head>
     <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width,initial-scale=1" />
+    <meta
+      name="viewport"
+      content="initial-scale=1, viewport-fit=cover, width=device-width"
+    />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta
+      name="apple-mobile-web-app-status-bar-style"
+      content="black-translucent"
+    />
     <title>TUS Santander - App</title>
     <style type="text/css">
       @font-face {

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,11 @@
   --color-blue: #0070f0;
   --color-light-blue: #32b0fd;
   --margin-lr: 14px;
+  padding-top: constant(safe-area-inset-top);
+  padding-top: env(safe-area-inset-top);
+  padding-right: env(safe-area-inset-right);
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-left: env(safe-area-inset-left);
 }
 
 body,


### PR DESCRIPTION
## Summary
- update the viewport meta tag to support viewport-fit=cover
- add Apple web app meta tags to use the entire screen space

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cfedb4b5f88327879e15e80991756a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved mobile experience with full-bleed layout on modern devices (notched/edge screens) via safe-area insets.
  * Enhanced PWA/iOS behavior for standalone display and refined status bar appearance.

* **Chores**
  * Updated HTML metadata and CSS to align with current mobile and PWA best practices without changing app logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->