### PR TITLE
Add safe area padding and remove redundant homescreen title meta

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,11 @@
   --color-blue: #0070f0;
   --color-light-blue: #32b0fd;
   --margin-lr: 14px;
+  padding-top: constant(safe-area-inset-top);
+  padding-top: env(safe-area-inset-top);
+  padding-right: env(safe-area-inset-right);
+  padding-bottom: env(safe-area-inset-bottom);
+  padding-left: env(safe-area-inset-left);
 }
 
 body,


### PR DESCRIPTION
## Summary
- provide safe-area padding on the root element to avoid content being obscured by notches when using a translucent status bar
- remove the redundant apple-mobile-web-app-title meta tag per review feedback

## Testing
- npm run lint *(fails: missing dependency eslint-plugin-react in repository configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68cff05624fc8327a56fa1666f28fbb9