### PR TITLE
Add Portuguese, French, and Italian translations

### DIFF
--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -1,0 +1,17 @@
+{
+  "favorites": "Favoris",
+  "map": "Carte",
+  "search": "Rechercher",
+  "done": "Terminé",
+  "use_map_or_search": "Utilisez la carte ou la recherche pour ajouter des arrêts",
+  "see_nearby_stops": "Voir les arrêts à proximité",
+  "confirm_remove_favorite": "Êtes-vous sûr de vouloir supprimer cet arrêt des favoris ?",
+  "location_not_available": "Localisation indisponible",
+  "no_available": "Non disponible",
+  "try_again": "Réessayer",
+  "view_route": "Voir l'itinéraire",
+  "refresh": "Actualiser",
+  "add_to_favorites": "Ajouter aux favoris",
+  "qr_code": "Code QR",
+  "desktop_instructions": "Scannez le code QR affiché à l'écran avec l'application <b>Appareil photo</b> de votre téléphone pour accéder à l'application"
+}

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -1,0 +1,17 @@
+{
+  "favorites": "Preferiti",
+  "map": "Mappa",
+  "search": "Cerca",
+  "done": "Fatto",
+  "use_map_or_search": "Usa la mappa o la ricerca per aggiungere fermate",
+  "see_nearby_stops": "Vedi le fermate vicine",
+  "confirm_remove_favorite": "Sei sicuro di voler rimuovere questa fermata dai preferiti?",
+  "location_not_available": "Posizione non disponibile",
+  "no_available": "Non disponibile",
+  "try_again": "Riprova",
+  "view_route": "Visualizza percorso",
+  "refresh": "Aggiorna",
+  "add_to_favorites": "Aggiungi ai preferiti",
+  "qr_code": "Codice QR",
+  "desktop_instructions": "Scansiona il codice QR mostrato sullo schermo con l'app <b>Fotocamera</b> del tuo telefono per accedere all'applicazione"
+}

--- a/src/i18n/pt.json
+++ b/src/i18n/pt.json
@@ -1,0 +1,17 @@
+{
+  "favorites": "Favoritos",
+  "map": "Mapa",
+  "search": "Pesquisar",
+  "done": "Concluído",
+  "use_map_or_search": "Use o mapa ou a pesquisa para adicionar paragens",
+  "see_nearby_stops": "Ver paragens próximas",
+  "confirm_remove_favorite": "Tem a certeza de que deseja remover esta paragem dos favoritos?",
+  "location_not_available": "Localização não disponível",
+  "no_available": "Não disponível",
+  "try_again": "Tentar novamente",
+  "view_route": "Ver percurso",
+  "refresh": "Atualizar",
+  "add_to_favorites": "Adicionar aos favoritos",
+  "qr_code": "Código QR",
+  "desktop_instructions": "Digitalize o código QR mostrado no ecrã com a aplicação <b>Câmara</b> do seu telemóvel para aceder à aplicação"
+}

--- a/src/providers/I18nProvider.jsx
+++ b/src/providers/I18nProvider.jsx
@@ -2,8 +2,11 @@ import { useState, useCallback, useEffect } from "react";
 import { I18nContext } from "../contexts/I18nContext.jsx";
 import es from "../i18n/es.json";
 import en from "../i18n/en.json";
+import pt from "../i18n/pt.json";
+import fr from "../i18n/fr.json";
+import it from "../i18n/it.json";
 
-const translations = { es, en };
+const translations = { es, en, pt, fr, it };
 
 export const I18nProvider = ({ children }) => {
   const browserLanguage = (() => {


### PR DESCRIPTION
## Summary
- add Portuguese, French, and Italian translation dictionaries
- register the new languages with the I18n provider so they are available at runtime

## Testing
- npm run lint *(fails: missing eslint-plugin-react dependency in project configuration)*

------
https://chatgpt.com/codex/tasks/task_e_68d6d119c07c83278ba050c676d15566

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added full French, Italian, and Portuguese language support across the app.
  * Translated UI labels, actions (Favorites, Map, Search), status messages, confirmations, and guidance (QR code scanning, desktop instructions).
  * Expanded automatic language detection to include these new locales.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->