### PR TITLE
Add basic telemetry

### DIFF
--- a/.github/workflows/deploy-environment.yml
+++ b/.github/workflows/deploy-environment.yml
@@ -56,6 +56,7 @@ jobs:
 
         env:
           VITE_APP_API_HOST: ${{ inputs.api-base-url }}
+          VITE_APP_TELEMETRY_HOST: ${{ vars.TELEMETRY_HOST }}
           VITE_APP_GOOGLE_MAPS_KEY: ${{ secrets.GOOGLE_MAPS_KEY }}
 
       - name: Prepare package

--- a/src/utils/ApiConstants.jsx
+++ b/src/utils/ApiConstants.jsx
@@ -1,5 +1,6 @@
 export const GOOGLE_MAPS_KEY = import.meta.env.VITE_APP_GOOGLE_MAPS_KEY;
 export const API_HOST = import.meta.env.VITE_APP_API_HOST;
+export const TELEMETRY_HOST = import.meta.env.VITE_APP_TELEMETRY_HOST;
 export const API_PATH_JSON_ESTIMATIONS = "/v4/estimations";
 export const API_PATH_JSON_ROUTE = "/v4/route";
 export const API_PATH_JSON_TELEMETRY = "/v4/telemetry";

--- a/src/utils/TelemetryUtils.jsx
+++ b/src/utils/TelemetryUtils.jsx
@@ -170,13 +170,6 @@ export const trackFavoriteToggle = (stopId, added) => {
   });
 };
 
-export const trackNavigation = (fromView, toView) => {
-  sendTelemetryEvent("navigate", {
-    from: fromView,
-    to: toView,
-  });
-};
-
 // Cleanup on page unload
 if (typeof window !== "undefined") {
   window.addEventListener("beforeunload", () => {

--- a/src/utils/TelemetryUtils.jsx
+++ b/src/utils/TelemetryUtils.jsx
@@ -1,9 +1,12 @@
-import { API_HOST, API_PATH_JSON_TELEMETRY } from "./ApiConstants.jsx";
+import {
+  API_HOST,
+  API_PATH_JSON_TELEMETRY,
+  TELEMETRY_HOST,
+} from "./ApiConstants.jsx";
 import { getFavorites } from "./FavoriteUtils.jsx";
 
 // Constants
-const TELEMETRY_URL =
-  "https://tusestimaciones-telemetry.miguelripoll23.deno.net/collect";
+const TELEMETRY_URL = `${TELEMETRY_HOST}/collect`;
 const USER_IDENTIFIER_KEY = "user_identifier";
 const SESSION_START_KEY = "session_start";
 const BATCH_SIZE = 5;

--- a/src/utils/TelemetryUtils.jsx
+++ b/src/utils/TelemetryUtils.jsx
@@ -8,7 +8,7 @@ import { getFavorites } from "./FavoriteUtils.jsx";
 // Constants
 const TELEMETRY_ENABLED =
   typeof TELEMETRY_HOST === "string" && TELEMETRY_HOST.length > 0;
-const TELEMETRY_URL = TELEMETRY_ENABLED ? `${TELEMETRY_HOST}/collect` : null;
+const TELEMETRY_URL = TELEMETRY_ENABLED ? `${TELEMETRY_HOST}/save` : null;
 const USER_IDENTIFIER_KEY = "user_identifier";
 const SESSION_START_KEY = "session_start";
 const BATCH_SIZE = 5;

--- a/src/utils/TelemetryUtils.jsx
+++ b/src/utils/TelemetryUtils.jsx
@@ -107,7 +107,7 @@ export const sendTelemetry = () => {
   // Only track on iPhone devices
   if (
     typeof navigator === "undefined" ||
-    !navigator.userAgent.includes("iPhone")
+    !/iphone/i.test(navigator.userAgent)
   ) {
     return;
   }
@@ -126,7 +126,7 @@ export const sendTelemetryEvent = (eventType, eventData = {}) => {
   // Only track on iPhone devices
   if (
     typeof navigator === "undefined" ||
-    !navigator.userAgent.includes("iPhone")
+    !/iphone/i.test(navigator.userAgent)
   ) {
     return;
   }

--- a/src/utils/TelemetryUtils.jsx
+++ b/src/utils/TelemetryUtils.jsx
@@ -49,20 +49,15 @@ const getDeviceInformation = () => {
 
 // Send data to server
 const sendToServer = async (payload) => {
-  try {
-    await fetch(TELEMETRY_URL, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        "X-Client-Version": "1.0",
-      },
-      body: JSON.stringify(payload),
-      keepalive: true,
-    });
-  } catch (error) {
-    // Silently fail - don't impact user experience
-    console.debug("Telemetry send failed:", error.message);
-  }
+  await fetch(TELEMETRY_URL, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "X-Client-Version": "1.0",
+    },
+    body: JSON.stringify(payload),
+    keepalive: true,
+  });
 };
 
 // Batch event processing
@@ -84,7 +79,13 @@ const processBatch = () => {
     events,
   };
 
-  sendToServer(payload);
+  sendToServer(payload).catch((error) => {
+    // If sending fails, add the events back to the front of the queue
+    // to be retried with the next batch.
+    eventQueue.unshift(...events);
+    // Silently fail - don't impact user experience
+    console.debug("Telemetry send failed:", error.message);
+  });
 };
 
 const addEventToBatch = (event) => {

--- a/src/utils/TelemetryUtils.jsx
+++ b/src/utils/TelemetryUtils.jsx
@@ -105,13 +105,39 @@ const addEventToBatch = (event) => {
   }
 };
 
+// Helper function to check if telemetry should be enabled
+const shouldTrackTelemetry = () => {
+  if (typeof navigator === "undefined") {
+    console.log("Telemetry skipped: navigator undefined");
+    return false;
+  }
+
+  if (!/iphone/i.test(navigator.userAgent)) {
+    console.log("Telemetry skipped: not iPhone device");
+    return false;
+  }
+
+  return true;
+};
+
+// Helper function to send remaining events using sendBeacon
+const sendRemainingEvents = () => {
+  if (eventQueue.length > 0) {
+    const payload = {
+      userId: getUserId(),
+      sessionId: getSessionId(),
+      deviceInformation: getDeviceInformation(),
+      events: eventQueue,
+    };
+
+    navigator.sendBeacon(TELEMETRY_URL, JSON.stringify(payload));
+    eventQueue = [];
+  }
+};
+
 // Main telemetry functions
 export const sendTelemetry = () => {
-  // Only track on iPhone devices
-  if (
-    typeof navigator === "undefined" ||
-    !/iphone/i.test(navigator.userAgent)
-  ) {
+  if (!shouldTrackTelemetry()) {
     return;
   }
 
@@ -126,11 +152,7 @@ export const sendTelemetry = () => {
 };
 
 export const sendTelemetryEvent = (eventType, eventData = {}) => {
-  // Only track on iPhone devices
-  if (
-    typeof navigator === "undefined" ||
-    !/iphone/i.test(navigator.userAgent)
-  ) {
+  if (!shouldTrackTelemetry()) {
     return;
   }
 
@@ -180,16 +202,12 @@ export const trackFavoriteToggle = (stopId, added) => {
 
 // Cleanup on page unload
 if (typeof window !== "undefined") {
-  window.addEventListener("beforeunload", () => {
-    if (eventQueue.length > 0) {
-      processBatch();
-    }
-  });
+  window.addEventListener("beforeunload", sendRemainingEvents);
 
   // Process remaining events when page becomes hidden
   document.addEventListener("visibilitychange", () => {
-    if (document.visibilityState === "hidden" && eventQueue.length > 0) {
-      processBatch();
+    if (document.visibilityState === "hidden") {
+      sendRemainingEvents();
     }
   });
 }

--- a/src/utils/TelemetryUtils.jsx
+++ b/src/utils/TelemetryUtils.jsx
@@ -1,9 +1,30 @@
 import { API_HOST, API_PATH_JSON_TELEMETRY } from "./ApiConstants.jsx";
 import { getFavorites } from "./FavoriteUtils.jsx";
 
-export const USER_IDENTIFIER_KEY = "user_identifier";
+// Constants
+const TELEMETRY_URL =
+  "https://tusestimaciones-telemetry.miguelripoll23.deno.net/collect";
+const USER_IDENTIFIER_KEY = "user_identifier";
+const SESSION_START_KEY = "session_start";
+const BATCH_SIZE = 5;
+const BATCH_TIMEOUT = 10000; // 10 seconds
 
-export const getUserIdentifier = () => {
+// Event queue for batching
+let eventQueue = [];
+let batchTimeout = null;
+
+// Session management
+const getSessionId = () => {
+  const sessionStart = sessionStorage.getItem(SESSION_START_KEY);
+  if (!sessionStart) {
+    const timestamp = Date.now();
+    sessionStorage.setItem(SESSION_START_KEY, timestamp.toString());
+    return timestamp;
+  }
+  return parseInt(sessionStart, 10);
+};
+
+const getUserId = () => {
   let identifier = localStorage.getItem(USER_IDENTIFIER_KEY);
   if (!identifier) {
     identifier = crypto.randomUUID();
@@ -12,26 +33,155 @@ export const getUserIdentifier = () => {
   return identifier;
 };
 
+// Device fingerprinting (minimal data)
+const getDeviceInformation = () => {
+  const userAgent = navigator.userAgent;
+
+  return {
+    // Shortened keys to reduce payload size
+    timeStamp: Date.now(), // timestamp
+    userAgent,
+    browserLanguage: navigator.language.split("-")[0], // Just language, not region
+    screenWidth: screen.width,
+    screenHeight: screen.height,
+  };
+};
+
+// Send data to server
+const sendToServer = async (payload) => {
+  try {
+    await fetch(TELEMETRY_URL, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        "X-Client-Version": "1.0",
+      },
+      body: JSON.stringify(payload),
+      keepalive: true,
+    });
+  } catch (error) {
+    // Silently fail - don't impact user experience
+    console.debug("Telemetry send failed:", error.message);
+  }
+};
+
+// Batch event processing
+const processBatch = () => {
+  if (eventQueue.length === 0) return;
+
+  const events = [...eventQueue];
+  eventQueue = [];
+
+  if (batchTimeout) {
+    clearTimeout(batchTimeout);
+    batchTimeout = null;
+  }
+
+  const payload = {
+    userId: getUserId(),
+    sessionId: getSessionId(),
+    deviceInformation: getDeviceInformation(),
+    events,
+  };
+
+  sendToServer(payload);
+};
+
+const addEventToBatch = (event) => {
+  eventQueue.push({
+    ...event,
+    timeStamp: Date.now(),
+  });
+
+  // Process batch if it's full or start timeout
+  if (eventQueue.length >= BATCH_SIZE) {
+    processBatch();
+  } else if (!batchTimeout) {
+    batchTimeout = setTimeout(processBatch, BATCH_TIMEOUT);
+  }
+};
+
+// Main telemetry functions
 export const sendTelemetry = () => {
-  if (typeof navigator === "undefined" || !/iPhone/i.test(navigator.userAgent)) {
+  // Only track on iPhone devices
+  if (
+    typeof navigator === "undefined" ||
+    !navigator.userAgent.includes("iPhone")
+  ) {
     return;
   }
 
-  const favorites = getFavorites().map((f) => f.stop_name);
+  const favorites = getFavorites();
 
-  const data = {
-    userIdentifier: getUserIdentifier(),
-    userAgent: navigator.userAgent,
-    language: navigator.language,
-    screenWidth: screen.width,
-    screenHeight: screen.height,
-    favorites,
-  };
-
-  fetch(API_HOST + API_PATH_JSON_TELEMETRY, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify(data),
-    keepalive: true,
-  }).catch(() => {});
+  addEventToBatch({
+    type: "app_start",
+    data: {
+      favorite_stops: favorites.map((f) => f.stop_name), // Stop names for better analytics
+    },
+  });
 };
+
+export const sendTelemetryEvent = (eventType, eventData = {}) => {
+  // Only track on iPhone devices
+  if (
+    typeof navigator === "undefined" ||
+    !navigator.userAgent.includes("iPhone")
+  ) {
+    return;
+  }
+
+  addEventToBatch({
+    type: eventType,
+    data: eventData,
+  });
+};
+
+// Specific event helpers
+export const trackStopEstimations = (stopId, stopName) => {
+  sendTelemetryEvent("stop_view", {
+    stop_name: stopName?.substring(0, 50) || "unknown", // Limit length
+  });
+};
+
+export const trackLineEstimations = (lineLabel, lineDestination) => {
+  sendTelemetryEvent("line_view", {
+    line: lineLabel,
+    destination: lineDestination?.substring(0, 30) || "unknown",
+  });
+};
+
+export const trackRefresh = (viewType, isAutoRefresh = false) => {
+  sendTelemetryEvent("refresh", {
+    view: viewType,
+    refresh: isAutoRefresh,
+  });
+};
+
+export const trackFavoriteToggle = (stopId, added) => {
+  sendTelemetryEvent("favorite", {
+    action: added ? "add" : "remove",
+  });
+};
+
+export const trackNavigation = (fromView, toView) => {
+  sendTelemetryEvent("navigate", {
+    from: fromView,
+    to: toView,
+  });
+};
+
+// Cleanup on page unload
+if (typeof window !== "undefined") {
+  window.addEventListener("beforeunload", () => {
+    if (eventQueue.length > 0) {
+      processBatch();
+    }
+  });
+
+  // Process remaining events when page becomes hidden
+  document.addEventListener("visibilitychange", () => {
+    if (document.visibilityState === "hidden" && eventQueue.length > 0) {
+      processBatch();
+    }
+  });
+}

--- a/src/utils/TelemetryUtils.jsx
+++ b/src/utils/TelemetryUtils.jsx
@@ -150,6 +150,13 @@ export const trackLineEstimations = (lineLabel, lineDestination) => {
   });
 };
 
+export const trackRouteView = (lineLabel, lineDestination) => {
+  sendTelemetryEvent("route_view", {
+    line: lineLabel,
+    destination: lineDestination?.substring(0, 30) || "unknown",
+  });
+};
+
 export const trackRefresh = (viewType, isAutoRefresh = false) => {
   sendTelemetryEvent("refresh", {
     view: viewType,

--- a/src/utils/TelemetryUtils.jsx
+++ b/src/utils/TelemetryUtils.jsx
@@ -6,7 +6,9 @@ import {
 import { getFavorites } from "./FavoriteUtils.jsx";
 
 // Constants
-const TELEMETRY_URL = `${TELEMETRY_HOST}/collect`;
+const TELEMETRY_ENABLED =
+  typeof TELEMETRY_HOST === "string" && TELEMETRY_HOST.length > 0;
+const TELEMETRY_URL = TELEMETRY_ENABLED ? `${TELEMETRY_HOST}/collect` : null;
 const USER_IDENTIFIER_KEY = "user_identifier";
 const SESSION_START_KEY = "session_start";
 const BATCH_SIZE = 5;
@@ -107,6 +109,11 @@ const addEventToBatch = (event) => {
 
 // Helper function to check if telemetry should be enabled
 const shouldTrackTelemetry = () => {
+  if (!TELEMETRY_ENABLED) {
+    console.log("Telemetry skipped: TELEMETRY_HOST not configured");
+    return false;
+  }
+
   if (typeof navigator === "undefined") {
     console.log("Telemetry skipped: navigator undefined");
     return false;
@@ -122,17 +129,19 @@ const shouldTrackTelemetry = () => {
 
 // Helper function to send remaining events using sendBeacon
 const sendRemainingEvents = () => {
-  if (eventQueue.length > 0) {
-    const payload = {
-      userId: getUserId(),
-      sessionId: getSessionId(),
-      deviceInformation: getDeviceInformation(),
-      events: eventQueue,
-    };
-
-    navigator.sendBeacon(TELEMETRY_URL, JSON.stringify(payload));
-    eventQueue = [];
+  if (!TELEMETRY_ENABLED || eventQueue.length === 0) {
+    return;
   }
+
+  const payload = {
+    userId: getUserId(),
+    sessionId: getSessionId(),
+    deviceInformation: getDeviceInformation(),
+    events: eventQueue,
+  };
+
+  navigator.sendBeacon(TELEMETRY_URL, JSON.stringify(payload));
+  eventQueue = [];
 };
 
 // Main telemetry functions

--- a/src/utils/TelemetryUtils.jsx
+++ b/src/utils/TelemetryUtils.jsx
@@ -157,6 +157,10 @@ export const trackRouteView = (lineLabel, lineDestination) => {
   });
 };
 
+export const trackMapView = () => {
+  sendTelemetryEvent("map_view", {});
+};
+
 export const trackRefresh = (viewType, isAutoRefresh = false) => {
   sendTelemetryEvent("refresh", {
     view: viewType,

--- a/src/views/estimations-line/EstimationsLineView.jsx
+++ b/src/views/estimations-line/EstimationsLineView.jsx
@@ -108,11 +108,16 @@ const EstimationsLineView = () => {
     getEstimations();
 
     // Auto-refresh
-    document.onvisibilitychange = () => {
+    const handleVisibilityChange = () => {
       if (document.visibilityState === "visible") {
         trackRefresh("line_estimations", true);
         refreshContent();
       }
+    };
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
   }, [getEstimations, refreshContent, lineLabel, lineDestination]);
 

--- a/src/views/estimations-line/EstimationsLineView.jsx
+++ b/src/views/estimations-line/EstimationsLineView.jsx
@@ -1,6 +1,11 @@
 import { Fragment, useCallback, useEffect, useState } from "react";
 import { useView } from "../../contexts/ViewContext.jsx";
 import { getLineBackgroundColor } from "../../utils/LineUtils.jsx";
+import {
+  trackLineEstimations,
+  trackRefresh,
+  trackNavigation,
+} from "../../utils/TelemetryUtils.jsx";
 
 import { VIEW_ID_ROUTE_LINE } from "../../constants/ViewConstants.jsx";
 
@@ -35,6 +40,11 @@ const EstimationsLineView = () => {
       // Reset
       setError(false);
       setEstimations([]);
+
+      // Track refresh events
+      if (update) {
+        trackRefresh("line_estimations", false);
+      }
 
       let query = `?stopId=${stopId}&lineLabel=${lineLabel}&lineDestination=${lineDestination}`;
 
@@ -84,6 +94,8 @@ const EstimationsLineView = () => {
 
   // Route
   const loadLineRouteView = () => {
+    trackNavigation("line_estimations", "route_view");
+
     setViewIdWithData(VIEW_ID_ROUTE_LINE, {
       stopId,
       lineLabel,
@@ -93,15 +105,19 @@ const EstimationsLineView = () => {
 
   // Mount
   useEffect(() => {
+    // Track page view
+    trackLineEstimations(lineLabel, lineDestination);
+
     getEstimations();
 
     // Auto-refresh
     document.onvisibilitychange = () => {
       if (document.visibilityState === "visible") {
+        trackRefresh("line_estimations", true);
         refreshContent();
       }
     };
-  }, [getEstimations, refreshContent]);
+  }, [getEstimations, refreshContent, lineLabel, lineDestination]);
 
   return (
     <Fragment>

--- a/src/views/estimations-line/EstimationsLineView.jsx
+++ b/src/views/estimations-line/EstimationsLineView.jsx
@@ -4,7 +4,6 @@ import { getLineBackgroundColor } from "../../utils/LineUtils.jsx";
 import {
   trackLineEstimations,
   trackRefresh,
-  trackNavigation,
 } from "../../utils/TelemetryUtils.jsx";
 
 import { VIEW_ID_ROUTE_LINE } from "../../constants/ViewConstants.jsx";
@@ -94,8 +93,6 @@ const EstimationsLineView = () => {
 
   // Route
   const loadLineRouteView = () => {
-    trackNavigation("line_estimations", "route_view");
-
     setViewIdWithData(VIEW_ID_ROUTE_LINE, {
       stopId,
       lineLabel,

--- a/src/views/estimations-stop/EstimationsStopView.jsx
+++ b/src/views/estimations-stop/EstimationsStopView.jsx
@@ -1,6 +1,12 @@
 import { Fragment, useCallback, useEffect, useState } from "react";
 import { useView } from "../../contexts/ViewContext.jsx";
 import { getFavorite, toggleFavorite } from "../../utils/FavoriteUtils.jsx";
+import {
+  trackStopEstimations,
+  trackRefresh,
+  trackFavoriteToggle,
+  trackNavigation,
+} from "../../utils/TelemetryUtils.jsx";
 
 import { VIEW_ID_ESTIMATIONS_LINE } from "../../constants/ViewConstants.jsx";
 
@@ -38,6 +44,11 @@ const EstimationsStopView = () => {
       // Reset
       setError(false);
       setEstimations([]);
+
+      // Track refresh events
+      if (update) {
+        trackRefresh("stop_estimations", false);
+      }
 
       let query = `?stopId=${stopId}`;
 
@@ -110,12 +121,18 @@ const EstimationsStopView = () => {
   };
 
   const syncFavoriteState = () => {
+    const wasFavorited = getFavorite(stopId) !== null;
     const heartState = toggleFavorite(stopId, stopName) ? 2 : 1;
     setHeartState(heartState);
+
+    // Track favorite toggle
+    trackFavoriteToggle(stopId, !wasFavorited);
   };
 
   // Line
   const loadEstimationsLineView = (result) => {
+    trackNavigation("stop_estimations", "line_estimations");
+
     setViewIdWithData(VIEW_ID_ESTIMATIONS_LINE, {
       stopId,
       stopName,
@@ -126,11 +143,15 @@ const EstimationsStopView = () => {
 
   // Mount
   useEffect(() => {
+    // Track page view
+    trackStopEstimations(stopId, stopName);
+
     getEstimations();
 
     // Auto-refresh
     document.onvisibilitychange = () => {
       if (document.visibilityState === "visible") {
+        trackRefresh("stop_estimations", true);
         refreshContent(true);
       }
     };
@@ -138,7 +159,7 @@ const EstimationsStopView = () => {
     return () => {
       document.onvisibilitychange = null;
     };
-  }, [getEstimations, refreshContent]);
+  }, [getEstimations, refreshContent, stopId, stopName]);
 
   return (
     <Fragment>

--- a/src/views/estimations-stop/EstimationsStopView.jsx
+++ b/src/views/estimations-stop/EstimationsStopView.jsx
@@ -146,15 +146,16 @@ const EstimationsStopView = () => {
     getEstimations();
 
     // Auto-refresh
-    document.onvisibilitychange = () => {
+    const handleVisibilityChange = () => {
       if (document.visibilityState === "visible") {
         trackRefresh("stop_estimations", true);
         refreshContent(true);
       }
     };
+    document.addEventListener("visibilitychange", handleVisibilityChange);
 
     return () => {
-      document.onvisibilitychange = null;
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
     };
   }, [getEstimations, refreshContent, stopId, stopName]);
 

--- a/src/views/estimations-stop/EstimationsStopView.jsx
+++ b/src/views/estimations-stop/EstimationsStopView.jsx
@@ -5,7 +5,6 @@ import {
   trackStopEstimations,
   trackRefresh,
   trackFavoriteToggle,
-  trackNavigation,
 } from "../../utils/TelemetryUtils.jsx";
 
 import { VIEW_ID_ESTIMATIONS_LINE } from "../../constants/ViewConstants.jsx";
@@ -131,8 +130,6 @@ const EstimationsStopView = () => {
 
   // Line
   const loadEstimationsLineView = (result) => {
-    trackNavigation("stop_estimations", "line_estimations");
-
     setViewIdWithData(VIEW_ID_ESTIMATIONS_LINE, {
       stopId,
       stopName,

--- a/src/views/home/subviews/HomeFavoritesSubview.jsx
+++ b/src/views/home/subviews/HomeFavoritesSubview.jsx
@@ -6,6 +6,10 @@ import {
   VIEW_ID_ESTIMATIONS_STOP,
   VIEW_ID_MAP,
 } from "../../../constants/ViewConstants.jsx";
+import {
+  sendTelemetryEvent,
+  trackNavigation,
+} from "../../../utils/TelemetryUtils.jsx";
 
 import Nav from "../../../components/Nav.jsx";
 import Error from "../../../components/Error.jsx";
@@ -83,6 +87,12 @@ const HomeFavoritesSubview = () => {
     setFavorites(favoritesOrdered);
     saveFavorites(favoritesOrdered);
 
+    // Track favorite reorder
+    sendTelemetryEvent("favorite_reorder", {
+      from_pos: sourceIndex,
+      to_pos: adjustedTargetIndex,
+    });
+
     return false;
   };
 
@@ -95,6 +105,13 @@ const HomeFavoritesSubview = () => {
     if (editMode) {
       return;
     }
+
+    // Track favorite selection
+    sendTelemetryEvent("favorite_select", {
+      stop_id: favorite.stop_id,
+    });
+
+    trackNavigation("favorites", "stop_estimations");
 
     setViewIdWithData(VIEW_ID_ESTIMATIONS_STOP, {
       stopId: favorite.stop_id,
@@ -114,7 +131,11 @@ const HomeFavoritesSubview = () => {
 
       return (
         <Fragment>
-          <Nav isHeader={true} titleText={getText("favorites")} hidden={isDesktop}>
+          <Nav
+            isHeader={true}
+            titleText={getText("favorites")}
+            hidden={isDesktop}
+          >
             <button
               className={styles.SortIconAndDoneLink}
               style={{ fontFamily, fontSize }}

--- a/src/views/home/subviews/HomeFavoritesSubview.jsx
+++ b/src/views/home/subviews/HomeFavoritesSubview.jsx
@@ -6,10 +6,7 @@ import {
   VIEW_ID_ESTIMATIONS_STOP,
   VIEW_ID_MAP,
 } from "../../../constants/ViewConstants.jsx";
-import {
-  sendTelemetryEvent,
-  trackNavigation,
-} from "../../../utils/TelemetryUtils.jsx";
+import { sendTelemetryEvent } from "../../../utils/TelemetryUtils.jsx";
 
 import Nav from "../../../components/Nav.jsx";
 import Error from "../../../components/Error.jsx";
@@ -110,8 +107,6 @@ const HomeFavoritesSubview = () => {
     sendTelemetryEvent("favorite_select", {
       stop_id: favorite.stop_id,
     });
-
-    trackNavigation("favorites", "stop_estimations");
 
     setViewIdWithData(VIEW_ID_ESTIMATIONS_STOP, {
       stopId: favorite.stop_id,

--- a/src/views/home/subviews/HomeSearchSubview.jsx
+++ b/src/views/home/subviews/HomeSearchSubview.jsx
@@ -2,6 +2,10 @@ import { Fragment, useEffect, useState } from "react";
 
 import { useView } from "../../../contexts/ViewContext.jsx";
 import { VIEW_ID_ESTIMATIONS_STOP } from "../../../constants/ViewConstants.jsx";
+import {
+  sendTelemetryEvent,
+  trackNavigation,
+} from "../../../utils/TelemetryUtils.jsx";
 
 import Nav from "../../../components/Nav.jsx";
 import Stops from "../../../json/stops.min.json";
@@ -58,6 +62,15 @@ const HomeSearchSubview = () => {
   }, [searchText]);
 
   const loadEstimationsStopView = (stopId, stopName) => {
+    // Track search result selection
+    sendTelemetryEvent("search_select", {
+      stop_id: stopId,
+      search_term: searchText?.substring(0, 20) || "", // Limit search term length
+      results_count: results.length,
+    });
+
+    trackNavigation("search", "stop_estimations");
+
     setViewIdWithData(VIEW_ID_ESTIMATIONS_STOP, {
       stopId,
       stopName,

--- a/src/views/home/subviews/HomeSearchSubview.jsx
+++ b/src/views/home/subviews/HomeSearchSubview.jsx
@@ -2,10 +2,7 @@ import { Fragment, useEffect, useState } from "react";
 
 import { useView } from "../../../contexts/ViewContext.jsx";
 import { VIEW_ID_ESTIMATIONS_STOP } from "../../../constants/ViewConstants.jsx";
-import {
-  sendTelemetryEvent,
-  trackNavigation,
-} from "../../../utils/TelemetryUtils.jsx";
+import { sendTelemetryEvent } from "../../../utils/TelemetryUtils.jsx";
 
 import Nav from "../../../components/Nav.jsx";
 import Stops from "../../../json/stops.min.json";
@@ -68,8 +65,6 @@ const HomeSearchSubview = () => {
       search_term: searchText?.substring(0, 20) || "", // Limit search term length
       results_count: results.length,
     });
-
-    trackNavigation("search", "stop_estimations");
 
     setViewIdWithData(VIEW_ID_ESTIMATIONS_STOP, {
       stopId,

--- a/src/views/map/MapView.jsx
+++ b/src/views/map/MapView.jsx
@@ -1,6 +1,7 @@
 import { Fragment, useCallback, useEffect, useState } from "react";
 import { APIProvider, Map } from "@vis.gl/react-google-maps";
 import { GOOGLE_MAPS_KEY } from "../../utils/ApiConstants.jsx";
+import { trackMapView } from "../../utils/TelemetryUtils.jsx";
 import { useI18n } from "../../contexts/I18nContext.jsx";
 
 import Nav from "../../components/Nav.jsx";
@@ -93,6 +94,9 @@ const MapView = () => {
 
   // Mount
   useEffect(() => {
+    // Track map view
+    trackMapView();
+    
     getCurrentLocation();
   }, [getCurrentLocation]);
 

--- a/src/views/route-line/RouteLineView.jsx
+++ b/src/views/route-line/RouteLineView.jsx
@@ -63,7 +63,7 @@ const RouteLineView = () => {
   useEffect(() => {
     // Track route view
     trackRouteView(lineLabel, lineDestination);
-    
+
     getStops();
   }, [getStops, lineLabel, lineDestination]);
 

--- a/src/views/route-line/RouteLineView.jsx
+++ b/src/views/route-line/RouteLineView.jsx
@@ -1,6 +1,7 @@
 import { Fragment, useCallback, useEffect, useState } from "react";
 import { useView } from "../../contexts/ViewContext.jsx";
 import { getLineBackgroundColor } from "../../utils/LineUtils.jsx";
+import { trackRouteView } from "../../utils/TelemetryUtils.jsx";
 import { API_HOST, API_PATH_JSON_ROUTE } from "../../utils/ApiConstants.jsx";
 
 import Main from "../../components/Main.jsx";
@@ -60,8 +61,11 @@ const RouteLineView = () => {
   }, [routes]);
 
   useEffect(() => {
+    // Track route view
+    trackRouteView(lineLabel, lineDestination);
+    
     getStops();
-  }, [getStops]);
+  }, [getStops, lineLabel, lineDestination]);
 
   const refreshContent = () => {
     setLoading(true);


### PR DESCRIPTION
Staging deploy requested.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added telemetry across the app to record page views, map/route/line/stop visits, refreshes, and user actions (search, favorite select/reorder, favorite toggle) to improve analytics.
  * Telemetry now batches and reliably sends events, including flushing on tab hide/close; no UI behavior changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->