### PR TITLE
feat: add missing translations (da, pl, ca)

### DIFF
--- a/src/i18n/ca.json
+++ b/src/i18n/ca.json
@@ -1,0 +1,20 @@
+{
+  "favorites": "Preferits",
+  "map": "Mapa",
+  "search": "Cerca",
+  "done": "Fet",
+  "use_map_or_search": "Utilitza el mapa o la cerca per afegir parades",
+  "see_nearby_stops": "Mira les parades properes",
+  "confirm_remove_favorite": "Estàs segur que vols eliminar aquesta parada dels preferits?",
+  "location_not_available": "La ubicació no està disponible",
+  "no_available": "No disponible",
+  "try_again": "Torna-ho a provar",
+  "view_route": "Veure ruta",
+  "refresh": "Actualitza",
+  "add_to_favorites": "Afegeix als preferits",
+  "qr_code": "Codi QR",
+  "desktop_instructions": "Escaneja el codi QR que apareix a la pantalla amb l'aplicació <b>Càmera</b> del teu telèfon per accedir a l'aplicació",
+  "donation_message": "Si trobes útil aquesta aplicació no oficial, pots donar-me suport amb una donació.",
+  "tip": "Propina",
+  "maybe_later": "Potser més tard"
+}

--- a/src/i18n/da.json
+++ b/src/i18n/da.json
@@ -1,0 +1,20 @@
+{
+  "favorites": "Favoritter",
+  "map": "Kort",
+  "search": "Søg",
+  "done": "Færdig",
+  "use_map_or_search": "Brug kortet eller søg for at tilføje stoppesteder",
+  "see_nearby_stops": "Se stoppesteder i nærheden",
+  "confirm_remove_favorite": "Er du sikker på, at du vil fjerne dette stoppested fra favoritter?",
+  "location_not_available": "Placering er ikke tilgængelig",
+  "no_available": "Ikke tilgængelig",
+  "try_again": "Prøv igen",
+  "view_route": "Vis rute",
+  "refresh": "Opdater",
+  "add_to_favorites": "Tilføj til favoritter",
+  "qr_code": "QR-kode",
+  "desktop_instructions": "Scan QR-koden på skærmen med din telefons <b>Kamera</b>-app for at få adgang til applikationen",
+  "donation_message": "Hvis du finder denne uofficielle app nyttig, kan du støtte mig med en donation.",
+  "tip": "Tip",
+  "maybe_later": "Måske senere"
+}

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -1,0 +1,20 @@
+{
+  "favorites": "Ulubione",
+  "map": "Mapa",
+  "search": "Szukaj",
+  "done": "Gotowe",
+  "use_map_or_search": "Użyj mapy lub wyszukiwarki, aby dodać przystanki",
+  "see_nearby_stops": "Zobacz pobliskie przystanki",
+  "confirm_remove_favorite": "Czy na pewno chcesz usunąć ten przystanek z ulubionych?",
+  "location_not_available": "Lokalizacja jest niedostępna",
+  "no_available": "Niedostępne",
+  "try_again": "Spróbuj ponownie",
+  "view_route": "Zobacz trasę",
+  "refresh": "Odśwież",
+  "add_to_favorites": "Dodaj do ulubionych",
+  "qr_code": "Kod QR",
+  "desktop_instructions": "Zeskanuj kod QR widoczny na ekranie za pomocą aplikacji <b>Aparat</b> w telefonie, aby uzyskać dostęp do aplikacji",
+  "donation_message": "Jeśli uważasz tę nieoficjalną aplikację za przydatną, możesz wesprzeć mnie darowizną.",
+  "tip": "Napiwek",
+  "maybe_later": "Może później"
+}

--- a/src/providers/I18nProvider.jsx
+++ b/src/providers/I18nProvider.jsx
@@ -1,15 +1,15 @@
 import { useState, useCallback, useEffect } from "react";
 import { I18nContext } from "../contexts/I18nContext.jsx";
-import es from "../i18n/es.json";
+import ca from "../i18n/ca.json";
+import da from "../i18n/da.json";
 import en from "../i18n/en.json";
-import pt from "../i18n/pt.json";
+import es from "../i18n/es.json";
 import fr from "../i18n/fr.json";
 import it from "../i18n/it.json";
-import da from "../i18n/da.json";
 import pl from "../i18n/pl.json";
-import ca from "../i18n/ca.json";
+import pt from "../i18n/pt.json";
 
-const translations = { es, en, pt, fr, it, da, pl, ca };
+const translations = { ca, da, en, es, fr, it, pl, pt };
 
 export const I18nProvider = ({ children }) => {
   const browserLanguage = (() => {

--- a/src/providers/I18nProvider.jsx
+++ b/src/providers/I18nProvider.jsx
@@ -5,8 +5,11 @@ import en from "../i18n/en.json";
 import pt from "../i18n/pt.json";
 import fr from "../i18n/fr.json";
 import it from "../i18n/it.json";
+import da from "../i18n/da.json";
+import pl from "../i18n/pl.json";
+import ca from "../i18n/ca.json";
 
-const translations = { es, en, pt, fr, it };
+const translations = { es, en, pt, fr, it, da, pl, ca };
 
 export const I18nProvider = ({ children }) => {
   const browserLanguage = (() => {


### PR DESCRIPTION
Added missing translations for Danish (da), Polish (pl), and Catalan (ca) as identified in the traffic report. Used English as the base for translations.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Catalan, Danish, and Polish languages
  * Expanded localization coverage with translations for all UI elements, labels, and user prompts in three new languages

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->