### PR TITLE
Remove unused @types/google.maps dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,6 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.2",
-    "@types/google.maps": "^3.64.0",
     "@types/react": "^19.2.11",
     "@types/react-dom": "^19.2.3",
     "@vitejs/plugin-react-swc": "^4.2.3",


### PR DESCRIPTION
Staging deploy requested.

## Changes
Removed the unused `@types/google.maps` package from devDependencies. This dependency is no longer needed by the project.

## Test Plan
N/A - Dependency removal with no source code changes. Verify build completes successfully.

https://claude.ai/code/session_013jawh54wGY3fh7mbRBeMph