### PR TITLE
Add interactive map card to route line view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,6 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.2",
-        "@types/google.maps": "^3.64.0",
         "@types/react": "^19.2.11",
         "@types/react-dom": "^19.2.3",
         "@vitejs/plugin-react-swc": "^4.2.3",

--- a/src/components/route-line/RouteMapCard.module.css
+++ b/src/components/route-line/RouteMapCard.module.css
@@ -1,81 +1,26 @@
-.sheet {
-  position: fixed;
-  bottom: 0;
-  left: 0;
-  right: 0;
-  z-index: 10;
-  height: 300px;
-  border-radius: 20px 20px 0 0;
+.card {
+  position: relative;
+  height: 200px;
+  margin: 14px var(--margin-lr);
+  border-radius: 16px;
   overflow: hidden;
-  backdrop-filter: blur(24px) saturate(180%);
-  -webkit-backdrop-filter: blur(24px) saturate(180%);
-  background-color: rgba(255, 255, 255, 0.88);
-  border-top: 1px solid rgba(255, 255, 255, 0.5);
-  box-shadow: 0 -2px 24px rgba(0, 0, 0, 0.1);
-  transition: height 0.35s cubic-bezier(0.4, 0, 0.2, 1);
   animation: fade-in 0.2s;
-
-  &[data-collapsed="true"] {
-    height: 68px;
-  }
-
-  @media (prefers-color-scheme: dark) {
-    background-color: rgba(28, 28, 30, 0.88);
-    border-top-color: rgba(255, 255, 255, 0.1);
-  }
 }
 
-.sheetHandle {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  width: 100%;
-  padding: 10px 16px 12px;
+.expandBtn {
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
+  z-index: 1;
+  padding: 6px 10px;
+  font-size: 18px;
+  line-height: 1;
   color: #000;
+  box-shadow: none;
 
   @media (prefers-color-scheme: dark) {
     color: #fff;
   }
-}
-
-.pill {
-  width: 36px;
-  height: 4px;
-  border-radius: 2px;
-  background: rgba(0, 0, 0, 0.18);
-  margin-bottom: 10px;
-  flex-shrink: 0;
-
-  @media (prefers-color-scheme: dark) {
-    background: rgba(255, 255, 255, 0.28);
-  }
-}
-
-.sheetHeader {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  width: 100%;
-}
-
-.sheetTitle {
-  font-size: 15px;
-  font-weight: 700;
-}
-
-.chevron {
-  font-size: 18px;
-  line-height: 1;
-  display: inline-block;
-  transition: transform 0.35s cubic-bezier(0.4, 0, 0.2, 1);
-
-  &[data-collapsed="true"] {
-    transform: rotate(180deg);
-  }
-}
-
-.sheetMap {
-  height: 224px;
 }
 
 .activePin {
@@ -84,4 +29,26 @@
   border-radius: 50%;
   border: 3px solid #fff;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
+}
+
+.fullscreen {
+  position: fixed;
+  inset: 0;
+  z-index: 999;
+}
+
+.closeBtn {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  z-index: 1000;
+  padding: 6px 12px;
+  font-size: 18px;
+  line-height: 1;
+  color: #000;
+  box-shadow: none;
+
+  @media (prefers-color-scheme: dark) {
+    color: #fff;
+  }
 }

--- a/src/components/route-line/RouteMapCard.module.css
+++ b/src/components/route-line/RouteMapCard.module.css
@@ -1,0 +1,54 @@
+.card {
+  position: relative;
+  height: 200px;
+  margin: 14px var(--margin-lr);
+  border-radius: 16px;
+  overflow: hidden;
+  animation: fade-in 0.2s;
+}
+
+.expandBtn {
+  position: absolute;
+  bottom: 10px;
+  right: 10px;
+  z-index: 1;
+  padding: 6px 10px;
+  font-size: 18px;
+  line-height: 1;
+  color: #000;
+  box-shadow: none;
+
+  @media (prefers-color-scheme: dark) {
+    color: #fff;
+  }
+}
+
+.activePin {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 3px solid #fff;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
+}
+
+.fullscreen {
+  position: fixed;
+  inset: 0;
+  z-index: 999;
+}
+
+.closeBtn {
+  position: absolute;
+  top: 16px;
+  right: 16px;
+  z-index: 1000;
+  padding: 6px 12px;
+  font-size: 18px;
+  line-height: 1;
+  color: #000;
+  box-shadow: none;
+
+  @media (prefers-color-scheme: dark) {
+    color: #fff;
+  }
+}

--- a/src/components/route-line/RouteMapCard.module.css
+++ b/src/components/route-line/RouteMapCard.module.css
@@ -1,26 +1,81 @@
-.card {
-  position: relative;
-  height: 200px;
-  margin: 14px var(--margin-lr);
-  border-radius: 16px;
+.sheet {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  z-index: 10;
+  height: 300px;
+  border-radius: 20px 20px 0 0;
   overflow: hidden;
+  backdrop-filter: blur(24px) saturate(180%);
+  -webkit-backdrop-filter: blur(24px) saturate(180%);
+  background-color: rgba(255, 255, 255, 0.88);
+  border-top: 1px solid rgba(255, 255, 255, 0.5);
+  box-shadow: 0 -2px 24px rgba(0, 0, 0, 0.1);
+  transition: height 0.35s cubic-bezier(0.4, 0, 0.2, 1);
   animation: fade-in 0.2s;
+
+  &[data-collapsed="true"] {
+    height: 68px;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    background-color: rgba(28, 28, 30, 0.88);
+    border-top-color: rgba(255, 255, 255, 0.1);
+  }
 }
 
-.expandBtn {
-  position: absolute;
-  bottom: 10px;
-  right: 10px;
-  z-index: 1;
-  padding: 6px 10px;
-  font-size: 18px;
-  line-height: 1;
+.sheetHandle {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 100%;
+  padding: 10px 16px 12px;
   color: #000;
-  box-shadow: none;
 
   @media (prefers-color-scheme: dark) {
     color: #fff;
   }
+}
+
+.pill {
+  width: 36px;
+  height: 4px;
+  border-radius: 2px;
+  background: rgba(0, 0, 0, 0.18);
+  margin-bottom: 10px;
+  flex-shrink: 0;
+
+  @media (prefers-color-scheme: dark) {
+    background: rgba(255, 255, 255, 0.28);
+  }
+}
+
+.sheetHeader {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  width: 100%;
+}
+
+.sheetTitle {
+  font-size: 15px;
+  font-weight: 700;
+}
+
+.chevron {
+  font-size: 18px;
+  line-height: 1;
+  display: inline-block;
+  transition: transform 0.35s cubic-bezier(0.4, 0, 0.2, 1);
+
+  &[data-collapsed="true"] {
+    transform: rotate(180deg);
+  }
+}
+
+.sheetMap {
+  height: 224px;
 }
 
 .activePin {
@@ -29,26 +84,4 @@
   border-radius: 50%;
   border: 3px solid #fff;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.4);
-}
-
-.fullscreen {
-  position: fixed;
-  inset: 0;
-  z-index: 999;
-}
-
-.closeBtn {
-  position: absolute;
-  top: 16px;
-  right: 16px;
-  z-index: 1000;
-  padding: 6px 12px;
-  font-size: 18px;
-  line-height: 1;
-  color: #000;
-  box-shadow: none;
-
-  @media (prefers-color-scheme: dark) {
-    color: #fff;
-  }
 }

--- a/src/components/route-line/RouteMapCard.tsx
+++ b/src/components/route-line/RouteMapCard.tsx
@@ -19,6 +19,7 @@ interface RouteMapCardProps {
   routes: RouteItemTuple[];
   activeStopId: number;
   lineLabel: string;
+  lineDestination: string;
 }
 
 interface StopMarker {
@@ -68,13 +69,26 @@ function RoutePolyline({ path, color }: RoutePolylineProps): null {
   return null;
 }
 
-function RouteMapCard({ routes, activeStopId, lineLabel }: RouteMapCardProps): ReactNode {
+function RouteMapCard({
+  routes,
+  activeStopId,
+  lineLabel,
+  lineDestination,
+}: RouteMapCardProps): ReactNode {
   const { getText } = useI18n();
   const { setViewIdWithData } = useView();
-  const [isFullscreen, setIsFullscreen] = useState(false);
+  const [isCollapsed, setIsCollapsed] = useState(false);
+  const [mapMounted, setMapMounted] = useState(false);
+
+  useEffect(() => {
+    const raf = requestAnimationFrame(() => setMapMounted(true));
+    return () => cancelAnimationFrame(raf);
+  }, []);
 
   const apiKey = GOOGLE_MAPS_KEY ?? "";
   const lineColor = getLineBackgroundColor(lineLabel, "string");
+  const defaultCenter = { lat: 43.462068, lng: -3.810204 };
+  const defaultZoom = 12;
 
   const stopMarkers: StopMarker[] = routes.reduce<StopMarker[]>((acc, [id, name]) => {
     const found = allMarkers.find((m) => m.id === id);
@@ -114,72 +128,45 @@ function RouteMapCard({ routes, activeStopId, lineLabel }: RouteMapCardProps): R
       );
     });
 
-  const defaultCenter = { lat: 43.462068, lng: -3.810204 };
-  const defaultZoom = 12;
-
-  const renderMapContent = (): ReactNode => (
-    <>
-      <BoundsFitter positions={positions} />
-      <RoutePolyline path={positions} color={lineColor} />
-      {renderMarkers()}
-    </>
-  );
-
-  const fullscreenOverlay = createPortal(
-    <div className={styles.fullscreen}>
-      <APIProvider apiKey={apiKey}>
-        <Map
-          mapId="91bb8a184defe594b79354e1"
-          colorScheme="FOLLOW_SYSTEM"
-          defaultZoom={defaultZoom}
-          defaultCenter={defaultCenter}
-          disableDefaultUI={true}
-          fullscreenControl={false}
-          gestureHandling="greedy"
-          style={{ width: "100%", height: "100%" }}
-        >
-          {renderMapContent()}
-        </Map>
-      </APIProvider>
+  return createPortal(
+    <div className={styles.sheet} data-collapsed={isCollapsed}>
       <button
         type="button"
-        className={`${styles.closeBtn} liquid-glass`}
-        aria-label={getText("close_map")}
-        onClick={() => setIsFullscreen(false)}
+        className={styles.sheetHandle}
+        aria-label={isCollapsed ? getText("expand_map") : getText("close_map")}
+        onClick={() => setIsCollapsed((c) => !c)}
       >
-        ✕
+        <span className={styles.pill} />
+        <div className={styles.sheetHeader}>
+          <span className={styles.sheetTitle}>
+            {lineLabel} {lineDestination.toUpperCase()}
+          </span>
+          <span className={styles.chevron} data-collapsed={isCollapsed}>
+            ∨
+          </span>
+        </div>
       </button>
+      <div className={styles.sheetMap}>
+        {mapMounted && (
+          <APIProvider apiKey={apiKey}>
+            <Map
+              mapId="91bb8a184defe594b79354e1"
+              colorScheme="FOLLOW_SYSTEM"
+              defaultZoom={defaultZoom}
+              defaultCenter={defaultCenter}
+              disableDefaultUI={true}
+              gestureHandling="greedy"
+              style={{ width: "100%", height: "100%" }}
+            >
+              <BoundsFitter positions={positions} />
+              <RoutePolyline path={positions} color={lineColor} />
+              {renderMarkers()}
+            </Map>
+          </APIProvider>
+        )}
+      </div>
     </div>,
     document.body
-  );
-
-  return (
-    <>
-      <div className={styles.card}>
-        <APIProvider apiKey={apiKey}>
-          <Map
-            mapId="91bb8a184defe594b79354e1"
-            colorScheme="FOLLOW_SYSTEM"
-            defaultZoom={defaultZoom}
-            defaultCenter={defaultCenter}
-            disableDefaultUI={true}
-            gestureHandling="cooperative"
-            style={{ width: "100%", height: "100%" }}
-          >
-            {renderMapContent()}
-          </Map>
-        </APIProvider>
-        <button
-          type="button"
-          className={`${styles.expandBtn} liquid-glass`}
-          aria-label={getText("expand_map")}
-          onClick={() => setIsFullscreen(true)}
-        >
-          ⛶
-        </button>
-      </div>
-      {isFullscreen && fullscreenOverlay}
-    </>
   );
 }
 

--- a/src/components/route-line/RouteMapCard.tsx
+++ b/src/components/route-line/RouteMapCard.tsx
@@ -19,7 +19,6 @@ interface RouteMapCardProps {
   routes: RouteItemTuple[];
   activeStopId: number;
   lineLabel: string;
-  lineDestination: string;
 }
 
 interface StopMarker {
@@ -69,15 +68,10 @@ function RoutePolyline({ path, color }: RoutePolylineProps): null {
   return null;
 }
 
-function RouteMapCard({
-  routes,
-  activeStopId,
-  lineLabel,
-  lineDestination,
-}: RouteMapCardProps): ReactNode {
+function RouteMapCard({ routes, activeStopId, lineLabel }: RouteMapCardProps): ReactNode {
   const { getText } = useI18n();
   const { setViewIdWithData } = useView();
-  const [isCollapsed, setIsCollapsed] = useState(false);
+  const [isFullscreen, setIsFullscreen] = useState(false);
   const [mapMounted, setMapMounted] = useState(false);
 
   useEffect(() => {
@@ -128,25 +122,47 @@ function RouteMapCard({
       );
     });
 
-  return createPortal(
-    <div className={styles.sheet} data-collapsed={isCollapsed}>
+  const renderMapContent = (): ReactNode => (
+    <>
+      <BoundsFitter positions={positions} />
+      <RoutePolyline path={positions} color={lineColor} />
+      {renderMarkers()}
+    </>
+  );
+
+  const fullscreenOverlay = createPortal(
+    <div className={styles.fullscreen}>
+      {mapMounted && (
+        <APIProvider apiKey={apiKey}>
+          <Map
+            mapId="91bb8a184defe594b79354e1"
+            colorScheme="FOLLOW_SYSTEM"
+            defaultZoom={defaultZoom}
+            defaultCenter={defaultCenter}
+            disableDefaultUI={true}
+            fullscreenControl={false}
+            gestureHandling="greedy"
+            style={{ width: "100%", height: "100%" }}
+          >
+            {renderMapContent()}
+          </Map>
+        </APIProvider>
+      )}
       <button
         type="button"
-        className={styles.sheetHandle}
-        aria-label={isCollapsed ? getText("expand_map") : getText("close_map")}
-        onClick={() => setIsCollapsed((c) => !c)}
+        className={`${styles.closeBtn} liquid-glass`}
+        aria-label={getText("close_map")}
+        onClick={() => setIsFullscreen(false)}
       >
-        <span className={styles.pill} />
-        <div className={styles.sheetHeader}>
-          <span className={styles.sheetTitle}>
-            {lineLabel} {lineDestination.toUpperCase()}
-          </span>
-          <span className={styles.chevron} data-collapsed={isCollapsed}>
-            ∨
-          </span>
-        </div>
+        ✕
       </button>
-      <div className={styles.sheetMap}>
+    </div>,
+    document.body
+  );
+
+  return (
+    <>
+      <div className={styles.card}>
         {mapMounted && (
           <APIProvider apiKey={apiKey}>
             <Map
@@ -155,18 +171,24 @@ function RouteMapCard({
               defaultZoom={defaultZoom}
               defaultCenter={defaultCenter}
               disableDefaultUI={true}
-              gestureHandling="greedy"
+              gestureHandling="cooperative"
               style={{ width: "100%", height: "100%" }}
             >
-              <BoundsFitter positions={positions} />
-              <RoutePolyline path={positions} color={lineColor} />
-              {renderMarkers()}
+              {renderMapContent()}
             </Map>
           </APIProvider>
         )}
+        <button
+          type="button"
+          className={`${styles.expandBtn} liquid-glass`}
+          aria-label={getText("expand_map")}
+          onClick={() => setIsFullscreen(true)}
+        >
+          ⛶
+        </button>
       </div>
-    </div>,
-    document.body
+      {isFullscreen && fullscreenOverlay}
+    </>
   );
 }
 

--- a/src/components/route-line/RouteMapCard.tsx
+++ b/src/components/route-line/RouteMapCard.tsx
@@ -1,0 +1,178 @@
+import React, { createPortal } from "react";
+import { useEffect, useState } from "react";
+import type { ReactNode } from "react";
+import { APIProvider, AdvancedMarker, Map, useMap } from "@vis.gl/react-google-maps";
+import type { RouteItemTuple } from "../../types/estimations";
+import type { MarkerPosition } from "../../interfaces/marker";
+import { GOOGLE_MAPS_KEY } from "../../utils/ApiConstants";
+import { getLineBackgroundColor } from "../../utils/LineUtils";
+import { useView } from "../../contexts/ViewContext";
+import { useI18n } from "../../contexts/I18nContext";
+import { VIEW_ID_ESTIMATIONS_STOP } from "../../constants/ViewConstants";
+import allMarkers from "../../utils/MarkerUtils";
+import MarkerMin from "../../assets/marker-min.png";
+
+import styles from "./RouteMapCard.module.css";
+
+interface RouteMapCardProps {
+  routes: RouteItemTuple[];
+  activeStopId: number;
+  lineLabel: string;
+}
+
+interface StopMarker {
+  id: number;
+  name: string;
+  position: MarkerPosition;
+}
+
+interface BoundsFitterProps {
+  positions: MarkerPosition[];
+}
+
+function BoundsFitter({ positions }: BoundsFitterProps): null {
+  const map = useMap();
+
+  useEffect(() => {
+    if (!map || positions.length === 0) return;
+    const bounds = new google.maps.LatLngBounds();
+    positions.forEach((pos) => bounds.extend(pos));
+    map.fitBounds(bounds, 32);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [map]);
+
+  return null;
+}
+
+interface RoutePolylineProps {
+  path: MarkerPosition[];
+  color: string;
+}
+
+function RoutePolyline({ path, color }: RoutePolylineProps): null {
+  const map = useMap();
+
+  useEffect(() => {
+    if (!map) return;
+    const line = new google.maps.Polyline({
+      path,
+      strokeColor: color,
+      strokeWeight: 4,
+      strokeOpacity: 0.9,
+    });
+    line.setMap(map);
+    return () => line.setMap(null);
+  }, [map, path, color]);
+
+  return null;
+}
+
+function RouteMapCard({ routes, activeStopId, lineLabel }: RouteMapCardProps): ReactNode {
+  const { getText } = useI18n();
+  const { setViewIdWithData } = useView();
+  const [isFullscreen, setIsFullscreen] = useState(false);
+
+  const apiKey = GOOGLE_MAPS_KEY ?? "";
+  const lineColor = getLineBackgroundColor(lineLabel, "string");
+
+  const stopMarkers: StopMarker[] = routes.reduce<StopMarker[]>((acc, [id, name]) => {
+    const found = allMarkers.find((m) => m.id === id);
+    if (found) acc.push({ id, name, position: found.position });
+    return acc;
+  }, []);
+
+  const positions = stopMarkers.map((m) => m.position);
+
+  const openStop = (stop: StopMarker): void => {
+    setViewIdWithData(VIEW_ID_ESTIMATIONS_STOP, {
+      stopId: stop.id,
+      stopName: stop.name,
+    });
+  };
+
+  const renderMarkers = (): ReactNode =>
+    stopMarkers.map((stop) => {
+      const isActive = stop.id === activeStopId;
+      return (
+        <AdvancedMarker
+          key={stop.id}
+          position={stop.position}
+          onClick={() => openStop(stop)}
+        >
+          {isActive ? (
+            <div
+              className={styles.activePin}
+              style={{ backgroundColor: lineColor }}
+            />
+          ) : (
+            <div className="marker">
+              <img alt="Pin" src={MarkerMin} />
+            </div>
+          )}
+        </AdvancedMarker>
+      );
+    });
+
+  const renderMapContent = (): ReactNode => (
+    <>
+      <BoundsFitter positions={positions} />
+      <RoutePolyline path={positions} color={lineColor} />
+      {renderMarkers()}
+    </>
+  );
+
+  const fullscreenOverlay = createPortal(
+    <div className={styles.fullscreen}>
+      <APIProvider apiKey={apiKey}>
+        <Map
+          mapId="91bb8a184defe594b79354e1"
+          colorScheme="FOLLOW_SYSTEM"
+          disableDefaultUI={false}
+          fullscreenControl={false}
+          gestureHandling="greedy"
+          style={{ width: "100%", height: "100%" }}
+        >
+          {renderMapContent()}
+        </Map>
+      </APIProvider>
+      <button
+        type="button"
+        className={`${styles.closeBtn} liquid-glass`}
+        aria-label={getText("close_map")}
+        onClick={() => setIsFullscreen(false)}
+      >
+        ✕
+      </button>
+    </div>,
+    document.body
+  );
+
+  return (
+    <>
+      <div className={styles.card}>
+        <APIProvider apiKey={apiKey}>
+          <Map
+            mapId="91bb8a184defe594b79354e1"
+            colorScheme="FOLLOW_SYSTEM"
+            disableDefaultUI={true}
+            gestureHandling="cooperative"
+            style={{ width: "100%", height: "100%" }}
+          >
+            {renderMapContent()}
+          </Map>
+        </APIProvider>
+        <button
+          type="button"
+          className={`${styles.expandBtn} liquid-glass`}
+          aria-label={getText("expand_map")}
+          onClick={() => setIsFullscreen(true)}
+        >
+          ⛶
+        </button>
+      </div>
+      {isFullscreen && fullscreenOverlay}
+    </>
+  );
+}
+
+export default RouteMapCard;

--- a/src/components/route-line/RouteMapCard.tsx
+++ b/src/components/route-line/RouteMapCard.tsx
@@ -128,7 +128,7 @@ function RouteMapCard({ routes, activeStopId, lineLabel }: RouteMapCardProps): R
         <Map
           mapId="91bb8a184defe594b79354e1"
           colorScheme="FOLLOW_SYSTEM"
-          disableDefaultUI={false}
+          disableDefaultUI={true}
           fullscreenControl={false}
           gestureHandling="greedy"
           style={{ width: "100%", height: "100%" }}

--- a/src/components/route-line/RouteMapCard.tsx
+++ b/src/components/route-line/RouteMapCard.tsx
@@ -1,5 +1,6 @@
-import React, { createPortal } from "react";
+import React from "react";
 import { useEffect, useState } from "react";
+import { createPortal } from "react-dom";
 import type { ReactNode } from "react";
 import { APIProvider, AdvancedMarker, Map, useMap } from "@vis.gl/react-google-maps";
 import type { RouteItemTuple } from "../../types/estimations";

--- a/src/components/route-line/RouteMapCard.tsx
+++ b/src/components/route-line/RouteMapCard.tsx
@@ -114,6 +114,9 @@ function RouteMapCard({ routes, activeStopId, lineLabel }: RouteMapCardProps): R
       );
     });
 
+  const defaultCenter = { lat: 43.462068, lng: -3.810204 };
+  const defaultZoom = 12;
+
   const renderMapContent = (): ReactNode => (
     <>
       <BoundsFitter positions={positions} />
@@ -128,6 +131,8 @@ function RouteMapCard({ routes, activeStopId, lineLabel }: RouteMapCardProps): R
         <Map
           mapId="91bb8a184defe594b79354e1"
           colorScheme="FOLLOW_SYSTEM"
+          defaultZoom={defaultZoom}
+          defaultCenter={defaultCenter}
           disableDefaultUI={true}
           fullscreenControl={false}
           gestureHandling="greedy"
@@ -155,6 +160,8 @@ function RouteMapCard({ routes, activeStopId, lineLabel }: RouteMapCardProps): R
           <Map
             mapId="91bb8a184defe594b79354e1"
             colorScheme="FOLLOW_SYSTEM"
+            defaultZoom={defaultZoom}
+            defaultCenter={defaultCenter}
             disableDefaultUI={true}
             gestureHandling="cooperative"
             style={{ width: "100%", height: "100%" }}

--- a/src/i18n/ca.json
+++ b/src/i18n/ca.json
@@ -16,5 +16,7 @@
   "desktop_instructions": "Escaneja el codi QR que apareix a la pantalla amb l'aplicació <b>Càmera</b> del teu telèfon per accedir a l'aplicació",
   "donation_message": "Si trobes útil aquesta aplicació no oficial, pots donar-me suport amb una donació.",
   "tip": "Convida'm a un cafè",
-  "maybe_later": "Potser més tard"
+  "maybe_later": "Potser més tard",
+  "expand_map": "Ampliar mapa",
+  "close_map": "Tancar mapa"
 }

--- a/src/i18n/da.json
+++ b/src/i18n/da.json
@@ -16,5 +16,7 @@
   "desktop_instructions": "Scan QR-koden på skærmen med din telefons <b>Kamera</b>-app for at få adgang til applikationen",
   "donation_message": "Hvis du finder denne uofficielle app nyttig, kan du støtte mig med en donation.",
   "tip": "Køb en kaffe til mig",
-  "maybe_later": "Måske senere"
+  "maybe_later": "Måske senere",
+  "expand_map": "Udvid kort",
+  "close_map": "Luk kort"
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -16,5 +16,7 @@
   "desktop_instructions": "Scan the QR code shown on screen using the <b>Camera</b> app on your phone to access the application",
   "donation_message": "If you find this unofficial app useful, you can support me with a donation.",
   "tip": "Buy me a coffee",
-  "maybe_later": "Maybe later"
+  "maybe_later": "Maybe later",
+  "expand_map": "Expand map",
+  "close_map": "Close map"
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -16,5 +16,7 @@
   "desktop_instructions": "Escanea el código QR que se muestra en la pantalla usando la app <b>Cámara</b> de tu móvil para acceder a la aplicación",
   "donation_message": "Si encuentras útil esta app no oficial, puedes apoyarme con un donativo.",
   "tip": "Invítame a un café",
-  "maybe_later": "Quizás luego"
+  "maybe_later": "Quizás luego",
+  "expand_map": "Ampliar mapa",
+  "close_map": "Cerrar mapa"
 }

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -16,5 +16,7 @@
   "desktop_instructions": "Scannez le code QR affiché à l'écran avec l'application <b>Appareil photo</b> de votre téléphone pour accéder à l'application",
   "donation_message": "Si vous trouvez cette app non officielle utile, vous pouvez me soutenir par un don.",
   "tip": "Offrez-moi un café",
-  "maybe_later": "Peut-être plus tard"
+  "maybe_later": "Peut-être plus tard",
+  "expand_map": "Agrandir la carte",
+  "close_map": "Fermer la carte"
 }

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -16,5 +16,7 @@
   "desktop_instructions": "Scansiona il codice QR mostrato sullo schermo con l'app <b>Fotocamera</b> del tuo telefono per accedere all'applicazione",
   "donation_message": "Se trovi utile questa app non ufficiale, puoi sostenermi con una donazione.",
   "tip": "Offrimi un caffè",
-  "maybe_later": "Forse più tardi"
+  "maybe_later": "Forse più tardi",
+  "expand_map": "Espandi mappa",
+  "close_map": "Chiudi mappa"
 }

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -16,5 +16,7 @@
   "desktop_instructions": "Zeskanuj kod QR widoczny na ekranie za pomocą aplikacji <b>Aparat</b> w telefonie, aby uzyskać dostęp do aplikacji",
   "donation_message": "Jeśli uważasz tę nieoficjalną aplikację za przydatną, możesz wesprzeć mnie darowizną.",
   "tip": "Postaw mi kawę",
-  "maybe_later": "Może później"
+  "maybe_later": "Może później",
+  "expand_map": "Rozwiń mapę",
+  "close_map": "Zamknij mapę"
 }

--- a/src/i18n/pt.json
+++ b/src/i18n/pt.json
@@ -16,5 +16,7 @@
   "desktop_instructions": "Digitalize o código QR mostrado no ecrã com a aplicação <b>Câmara</b> do seu telemóvel para aceder à aplicação",
   "donation_message": "Se considera esta aplicação não oficial útil, pode apoiar-me com uma doação.",
   "tip": "Pague-me um café",
-  "maybe_later": "Talvez mais tarde"
+  "maybe_later": "Talvez mais tarde",
+  "expand_map": "Expandir mapa",
+  "close_map": "Fechar mapa"
 }

--- a/src/views/route-line/RouteLineView.tsx
+++ b/src/views/route-line/RouteLineView.tsx
@@ -15,6 +15,7 @@ import Nav from "../../components/Nav";
 import Spinner from "../../components/Spinner";
 import ErrorDisplay from "../../components/Error";
 import StopLines from "../../components/StopLines";
+import RouteMapCard from "../../components/route-line/RouteMapCard";
 import { useI18n } from "../../contexts/I18nContext";
 
 import styles from "./RouteLineView.module.css";
@@ -96,6 +97,13 @@ function RouteLineView(): React.JSX.Element {
             errorText={getText("no_available")}
             retryText={getText("try_again")}
             retryAction={refreshContent}
+          />
+        )}
+        {routes.length > 0 && (
+          <RouteMapCard
+            routes={routes}
+            activeStopId={stopId}
+            lineLabel={lineLabel}
           />
         )}
         <ul className={styles.routeLineList}>

--- a/src/views/route-line/RouteLineView.tsx
+++ b/src/views/route-line/RouteLineView.tsx
@@ -90,7 +90,7 @@ function RouteLineView(): React.JSX.Element {
         isHeader={false}
         titleText={`${lineLabel} ${lineDestination.toUpperCase()}`}
       />
-      <Main paddingTop="64px" paddingBottom="40px">
+      <Main paddingTop="64px" paddingBottom="300px">
         {loading && <Spinner />}
         {error && (
           <ErrorDisplay
@@ -104,6 +104,7 @@ function RouteLineView(): React.JSX.Element {
             routes={routes}
             activeStopId={stopId}
             lineLabel={lineLabel}
+            lineDestination={lineDestination}
           />
         )}
         <ul className={styles.routeLineList}>

--- a/src/views/route-line/RouteLineView.tsx
+++ b/src/views/route-line/RouteLineView.tsx
@@ -90,7 +90,7 @@ function RouteLineView(): React.JSX.Element {
         isHeader={false}
         titleText={`${lineLabel} ${lineDestination.toUpperCase()}`}
       />
-      <Main paddingTop="64px" paddingBottom="300px">
+      <Main paddingTop="64px" paddingBottom="40px">
         {loading && <Spinner />}
         {error && (
           <ErrorDisplay
@@ -104,7 +104,6 @@ function RouteLineView(): React.JSX.Element {
             routes={routes}
             activeStopId={stopId}
             lineLabel={lineLabel}
-            lineDestination={lineDestination}
           />
         )}
         <ul className={styles.routeLineList}>


### PR DESCRIPTION
Staging deploy requested.

## Changes

Added a new `RouteMapCard` component that displays an interactive Google Map showing all stops on a transit route with the following features:

- **Map visualization**: Displays route stops as markers with polyline connecting them
- **Active stop highlighting**: The currently selected stop is highlighted with a colored pin matching the route line color
- **Fullscreen mode**: Users can expand the map to fullscreen with a dedicated close button
- **Stop interaction**: Clicking on any marker navigates to that stop's details
- **Responsive design**: Compact card view (200px height) with expand/collapse functionality
- **Accessibility**: Proper ARIA labels for expand and close buttons

### New Files
- `src/components/route-line/RouteMapCard.tsx` - Main component with map rendering logic
- `src/components/route-line/RouteMapCard.module.css` - Styling for card and fullscreen modes

### Modified Files
- `src/views/route-line/RouteLineView.tsx` - Integrated RouteMapCard into the route line view
- `src/i18n/*.json` - Added translations for "expand_map" and "close_map" across all supported languages (EN, CA, DA, ES, FR, IT, PL, PT)

## Implementation Details

The component uses:
- Google Maps API via `@vis.gl/react-google-maps`
- Custom `BoundsFitter` component to auto-fit map bounds to all stops
- Custom `RoutePolyline` component to render the route path
- Portal rendering for fullscreen overlay to avoid z-index stacking issues
- System color scheme preference detection for dark mode support

The map is integrated into the existing RouteLineView and displays only when routes are available.

https://claude.ai/code/session_01DueUEUSFTRnTXQwYvL5mKR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added interactive map card to display routes with stop markers and visual indicators.
  * Users can expand the map to fullscreen for better visibility.
  * Added close button for exiting fullscreen map view.

* **Internationalization**
  * Translated map expand and close labels into Catalan, Danish, English, Spanish, French, Italian, Polish, and Portuguese.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->