### PR TITLE
Add Trip planner tab with route planning interface

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -9,10 +9,12 @@ interface NavProps {
   isHeader: boolean;
   titleText: string;
   children?: ReactNode;
+  onBack?: () => void;
 }
 
-function Nav({ isHeader, titleText, children }: NavProps): React.JSX.Element {
+function Nav({ isHeader, titleText, children, onBack }: NavProps): React.JSX.Element {
   const goBack = (): void => {
+    if (onBack) { onBack(); return; }
     globalThis.history.back();
   };
 

--- a/src/components/home/HomeMenu.tsx
+++ b/src/components/home/HomeMenu.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { ReactNode } from "react";
 import type { SubViewId, ViewId } from "../../types/view";
-import { Heart, Map, Search } from "lucide-react";
+import { Heart, Map, Search, Navigation } from "lucide-react";
 import styles from "./HomeMenu.module.css";
 import { useView } from "../../contexts/ViewContext";
 import { useI18n } from "../../contexts/I18nContext";
@@ -9,6 +9,7 @@ import {
   SUB_VIEW_ID_FAVORITES,
   SUB_VIEW_ID_MAP,
   SUB_VIEW_ID_SEARCH,
+  SUB_VIEW_ID_TRIP,
   VIEW_ID_MAP,
 } from "../../constants/ViewConstants";
 
@@ -30,6 +31,12 @@ function buildMenuItems(
       icon: <Heart size={26} fill="currentColor" aria-hidden="true" />,
       label: getText("favorites"),
       onClick: () => setSubViewId(SUB_VIEW_ID_FAVORITES),
+    },
+    {
+      id: SUB_VIEW_ID_TRIP,
+      icon: <Navigation size={26} aria-hidden="true" />,
+      label: getText("trip"),
+      onClick: () => setSubViewId(SUB_VIEW_ID_TRIP),
     },
     {
       id: SUB_VIEW_ID_MAP,

--- a/src/components/home/HomeMenu.tsx
+++ b/src/components/home/HomeMenu.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { ReactNode } from "react";
 import type { SubViewId, ViewId } from "../../types/view";
-import { Heart, Map, Search, Navigation } from "lucide-react";
+import { Heart, Map, Search, Route } from "lucide-react";
 import styles from "./HomeMenu.module.css";
 import { useView } from "../../contexts/ViewContext";
 import { useI18n } from "../../contexts/I18nContext";
@@ -34,7 +34,7 @@ function buildMenuItems(
     },
     {
       id: SUB_VIEW_ID_TRIP,
-      icon: <Navigation size={26} aria-hidden="true" />,
+      icon: <Route size={26} aria-hidden="true" />,
       label: getText("trip"),
       onClick: () => setSubViewId(SUB_VIEW_ID_TRIP),
     },

--- a/src/constants/ViewConstants.ts
+++ b/src/constants/ViewConstants.ts
@@ -12,10 +12,12 @@ export const VIEW_ID_ROUTE_LINE: ViewId = "route_line";
 export const SUB_VIEW_ID_FAVORITES: SubViewId = "favorites";
 export const SUB_VIEW_ID_MAP: SubViewId = "map";
 export const SUB_VIEW_ID_SEARCH: SubViewId = "search";
+export const SUB_VIEW_ID_TRIP: SubViewId = "trip";
 
 export const SUB_VIEW_TITLE_FAVORITES = "favorites";
 export const SUB_VIEW_TITLE_MAP = "map";
 export const SUB_VIEW_TITLE_SEARCH = "search";
+export const SUB_VIEW_TITLE_TRIP = "trip";
 
 export const SET_VIEW_ID = "SET_VIEW_ID";
 export const SET_VIEW_ID_WITH_DATA = "SET_VIEW_ID_WITH_DATA";

--- a/src/i18n/ca.json
+++ b/src/i18n/ca.json
@@ -2,6 +2,7 @@
   "favorites": "Preferits",
   "map": "Mapa",
   "search": "Cerca",
+  "trip": "Viatge",
   "done": "Fet",
   "use_map_or_search": "Utilitza el mapa o la cerca per afegir parades",
   "see_nearby_stops": "Mira les parades properes",
@@ -18,5 +19,16 @@
   "tip": "Convida'm a un cafè",
   "maybe_later": "Potser més tard",
   "expand_map": "Ampliar mapa",
-  "close_map": "Tancar mapa"
+  "close_map": "Tancar mapa",
+  "from": "Des de",
+  "to": "Fins a",
+  "current_location": "Ubicació actual",
+  "no_routes_found": "No s'han trobat rutes",
+  "plan_trip": "Planificar viatge",
+  "bus": "Autobús",
+  "walk": "Caminar",
+  "transfer": "Transbordo",
+  "minutes": "min",
+  "arrival": "Arribada",
+  "departure": "Sortida"
 }

--- a/src/i18n/ca.json
+++ b/src/i18n/ca.json
@@ -27,7 +27,7 @@
   "plan_trip": "Planificar viatge",
   "bus": "Autobús",
   "walk": "Caminar",
-  "transfer": "Transbordo",
+  "transfer": "Transbord",
   "minutes": "min",
   "arrival": "Arribada",
   "departure": "Sortida"

--- a/src/i18n/da.json
+++ b/src/i18n/da.json
@@ -2,6 +2,7 @@
   "favorites": "Favoritter",
   "map": "Kort",
   "search": "Søg",
+  "trip": "Tur",
   "done": "Færdig",
   "use_map_or_search": "Brug kortet eller søg for at tilføje stoppesteder",
   "see_nearby_stops": "Se stoppesteder i nærheden",
@@ -18,5 +19,16 @@
   "tip": "Køb en kaffe til mig",
   "maybe_later": "Måske senere",
   "expand_map": "Udvid kort",
-  "close_map": "Luk kort"
+  "close_map": "Luk kort",
+  "from": "Fra",
+  "to": "Til",
+  "current_location": "Aktuel placering",
+  "no_routes_found": "Ingen ruter fundet",
+  "plan_trip": "Planlæg tur",
+  "bus": "Bus",
+  "walk": "Gå",
+  "transfer": "Skift",
+  "minutes": "min",
+  "arrival": "Ankomst",
+  "departure": "Afgang"
 }

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -25,6 +25,7 @@
   "current_location": "Current Location",
   "no_routes_found": "No routes found",
   "plan_trip": "Plan Trip",
+  "trip_empty_hint": "Enter an origin and destination to find available routes",
   "bus": "Bus",
   "walk": "Walk",
   "transfer": "Transfer",

--- a/src/i18n/en.json
+++ b/src/i18n/en.json
@@ -2,6 +2,7 @@
   "favorites": "Favorites",
   "map": "Map",
   "search": "Search",
+  "trip": "Trip",
   "done": "Done",
   "use_map_or_search": "Use the map or search to add stops",
   "see_nearby_stops": "See nearby stops",
@@ -18,5 +19,16 @@
   "tip": "Buy me a coffee",
   "maybe_later": "Maybe later",
   "expand_map": "Expand map",
-  "close_map": "Close map"
+  "close_map": "Close map",
+  "from": "From",
+  "to": "To",
+  "current_location": "Current Location",
+  "no_routes_found": "No routes found",
+  "plan_trip": "Plan Trip",
+  "bus": "Bus",
+  "walk": "Walk",
+  "transfer": "Transfer",
+  "minutes": "min",
+  "arrival": "Arrival",
+  "departure": "Departure"
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -2,6 +2,7 @@
   "favorites": "Favoritos",
   "map": "Mapa",
   "search": "Buscar",
+  "trip": "Viaje",
   "done": "Hecho",
   "use_map_or_search": "Usa el mapa o el buscador para añadir paradas",
   "see_nearby_stops": "Ver paradas cercanas",
@@ -18,5 +19,16 @@
   "tip": "Invítame a un café",
   "maybe_later": "Quizás luego",
   "expand_map": "Ampliar mapa",
-  "close_map": "Cerrar mapa"
+  "close_map": "Cerrar mapa",
+  "from": "Desde",
+  "to": "Hacia",
+  "current_location": "Ubicación actual",
+  "no_routes_found": "No se encontraron rutas",
+  "plan_trip": "Planificar viaje",
+  "bus": "Autobús",
+  "walk": "Caminar",
+  "transfer": "Transferencia",
+  "minutes": "min",
+  "arrival": "Llegada",
+  "departure": "Salida"
 }

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -27,7 +27,7 @@
   "plan_trip": "Planificar viaje",
   "bus": "Autobús",
   "walk": "Caminar",
-  "transfer": "Transferencia",
+  "transfer": "Transbordo",
   "minutes": "min",
   "arrival": "Llegada",
   "departure": "Salida"

--- a/src/i18n/es.json
+++ b/src/i18n/es.json
@@ -25,6 +25,7 @@
   "current_location": "Ubicación actual",
   "no_routes_found": "No se encontraron rutas",
   "plan_trip": "Planificar viaje",
+  "trip_empty_hint": "Introduce un origen y destino para encontrar rutas disponibles",
   "bus": "Autobús",
   "walk": "Caminar",
   "transfer": "Transbordo",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -20,7 +20,7 @@
   "maybe_later": "Peut-être plus tard",
   "expand_map": "Agrandir la carte",
   "close_map": "Fermer la carte",
-  "from": "Départ",
+  "from": "De",
   "to": "Destination",
   "current_location": "Position actuelle",
   "no_routes_found": "Aucun itinéraire trouvé",

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -2,6 +2,7 @@
   "favorites": "Favoris",
   "map": "Carte",
   "search": "Rechercher",
+  "trip": "Trajet",
   "done": "Terminé",
   "use_map_or_search": "Utilisez la carte ou la recherche pour ajouter des arrêts",
   "see_nearby_stops": "Voir les arrêts à proximité",
@@ -18,5 +19,16 @@
   "tip": "Offrez-moi un café",
   "maybe_later": "Peut-être plus tard",
   "expand_map": "Agrandir la carte",
-  "close_map": "Fermer la carte"
+  "close_map": "Fermer la carte",
+  "from": "Départ",
+  "to": "Destination",
+  "current_location": "Position actuelle",
+  "no_routes_found": "Aucun itinéraire trouvé",
+  "plan_trip": "Planifier un trajet",
+  "bus": "Bus",
+  "walk": "Marcher",
+  "transfer": "Correspondance",
+  "minutes": "min",
+  "arrival": "Arrivée",
+  "departure": "Départ"
 }

--- a/src/i18n/fr.json
+++ b/src/i18n/fr.json
@@ -25,6 +25,7 @@
   "current_location": "Position actuelle",
   "no_routes_found": "Aucun itinéraire trouvé",
   "plan_trip": "Planifier un trajet",
+  "trip_empty_hint": "Entrez une origine et une destination pour trouver les itinéraires disponibles",
   "bus": "Bus",
   "walk": "Marcher",
   "transfer": "Correspondance",

--- a/src/i18n/it.json
+++ b/src/i18n/it.json
@@ -2,6 +2,7 @@
   "favorites": "Preferiti",
   "map": "Mappa",
   "search": "Cerca",
+  "trip": "Viaggio",
   "done": "Fatto",
   "use_map_or_search": "Usa la mappa o la ricerca per aggiungere fermate",
   "see_nearby_stops": "Vedi le fermate vicine",
@@ -18,5 +19,16 @@
   "tip": "Offrimi un caffè",
   "maybe_later": "Forse più tardi",
   "expand_map": "Espandi mappa",
-  "close_map": "Chiudi mappa"
+  "close_map": "Chiudi mappa",
+  "from": "Da",
+  "to": "A",
+  "current_location": "Posizione attuale",
+  "no_routes_found": "Nessun itinerario trovato",
+  "plan_trip": "Pianifica viaggio",
+  "bus": "Bus",
+  "walk": "Cammina",
+  "transfer": "Cambio",
+  "minutes": "min",
+  "arrival": "Arrivo",
+  "departure": "Partenza"
 }

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -26,7 +26,7 @@
   "no_routes_found": "Nie znaleziono tras",
   "plan_trip": "Zaplanuj podróż",
   "bus": "Autobus",
-  "walk": "Chodzić",
+  "walk": "Pieszo",
   "transfer": "Transfer",
   "minutes": "min",
   "arrival": "Przyjazd",

--- a/src/i18n/pl.json
+++ b/src/i18n/pl.json
@@ -2,6 +2,7 @@
   "favorites": "Ulubione",
   "map": "Mapa",
   "search": "Szukaj",
+  "trip": "Podróż",
   "done": "Gotowe",
   "use_map_or_search": "Użyj mapy lub wyszukiwarki, aby dodać przystanki",
   "see_nearby_stops": "Zobacz pobliskie przystanki",
@@ -18,5 +19,16 @@
   "tip": "Postaw mi kawę",
   "maybe_later": "Może później",
   "expand_map": "Rozwiń mapę",
-  "close_map": "Zamknij mapę"
+  "close_map": "Zamknij mapę",
+  "from": "Z",
+  "to": "Do",
+  "current_location": "Bieżąca lokalizacja",
+  "no_routes_found": "Nie znaleziono tras",
+  "plan_trip": "Zaplanuj podróż",
+  "bus": "Autobus",
+  "walk": "Chodzić",
+  "transfer": "Transfer",
+  "minutes": "min",
+  "arrival": "Przyjazd",
+  "departure": "Wyjazd"
 }

--- a/src/i18n/pt.json
+++ b/src/i18n/pt.json
@@ -2,6 +2,7 @@
   "favorites": "Favoritos",
   "map": "Mapa",
   "search": "Pesquisar",
+  "trip": "Viagem",
   "done": "Concluído",
   "use_map_or_search": "Use o mapa ou a pesquisa para adicionar paragens",
   "see_nearby_stops": "Ver paragens próximas",
@@ -18,5 +19,16 @@
   "tip": "Pague-me um café",
   "maybe_later": "Talvez mais tarde",
   "expand_map": "Expandir mapa",
-  "close_map": "Fechar mapa"
+  "close_map": "Fechar mapa",
+  "from": "De",
+  "to": "Para",
+  "current_location": "Localização atual",
+  "no_routes_found": "Nenhuma rota encontrada",
+  "plan_trip": "Planificar viagem",
+  "bus": "Autocarro",
+  "walk": "Caminhar",
+  "transfer": "Transbordo",
+  "minutes": "min",
+  "arrival": "Chegada",
+  "departure": "Partida"
 }

--- a/src/types/view.ts
+++ b/src/types/view.ts
@@ -5,4 +5,4 @@ export type ViewId =
   | "estimations_line"
   | "route_line";
 
-export type SubViewId = "favorites" | "map" | "search";
+export type SubViewId = "favorites" | "map" | "search" | "trip";

--- a/src/utils/PlacesUtils.ts
+++ b/src/utils/PlacesUtils.ts
@@ -1,0 +1,98 @@
+import { GOOGLE_MAPS_KEY } from "./ApiConstants";
+
+let loadPromise: Promise<void> | null = null;
+
+function loadMapsApi(): Promise<void> {
+  if (loadPromise) return loadPromise;
+  if (!GOOGLE_MAPS_KEY) return Promise.reject(new Error("No API key"));
+
+  loadPromise = new Promise<void>((resolve, reject) => {
+    if ((window as Window & typeof globalThis & { google?: { maps?: unknown } }).google?.maps) {
+      resolve();
+      return;
+    }
+    const cb = "__mapsReady";
+    (window as Record<string, unknown>)[cb] = resolve;
+    const script = document.createElement("script");
+    script.src = `https://maps.googleapis.com/maps/api/js?key=${GOOGLE_MAPS_KEY}&libraries=places&callback=${cb}&language=es`;
+    script.async = true;
+    script.onerror = () => reject(new Error("Failed to load Maps API"));
+    document.head.appendChild(script);
+  });
+
+  return loadPromise;
+}
+
+export interface PlacePrediction {
+  placeId: string;
+  mainText: string;
+  secondaryText: string;
+}
+
+let autocompleteService: google.maps.places.AutocompleteService | null = null;
+let placesService: google.maps.places.PlacesService | null = null;
+let placesDiv: HTMLDivElement | null = null;
+
+export async function getPlacePredictions(input: string): Promise<PlacePrediction[]> {
+  if (!input.trim() || !GOOGLE_MAPS_KEY) return [];
+
+  try {
+    await loadMapsApi();
+    if (!autocompleteService) {
+      autocompleteService = new google.maps.places.AutocompleteService();
+    }
+
+    return new Promise((resolve) => {
+      autocompleteService!.getPlacePredictions(
+        {
+          input,
+          location: new google.maps.LatLng(43.4628, -3.8099),
+          radius: 20000,
+          componentRestrictions: { country: "es" },
+        },
+        (predictions, status) => {
+          if (status !== google.maps.places.PlacesServiceStatus.OK || !predictions) {
+            resolve([]);
+            return;
+          }
+          resolve(
+            predictions.slice(0, 5).map((p) => ({
+              placeId: p.place_id,
+              mainText: p.structured_formatting.main_text,
+              secondaryText: p.structured_formatting.secondary_text ?? "",
+            }))
+          );
+        }
+      );
+    });
+  } catch {
+    return [];
+  }
+}
+
+export async function getPlaceCoordinates(
+  placeId: string
+): Promise<{ lat: number; lng: number } | null> {
+  try {
+    await loadMapsApi();
+    if (!placesDiv) placesDiv = document.createElement("div");
+    if (!placesService) {
+      placesService = new google.maps.places.PlacesService(placesDiv);
+    }
+
+    return new Promise((resolve) => {
+      placesService!.getDetails({ placeId, fields: ["geometry"] }, (place, status) => {
+        if (
+          status !== google.maps.places.PlacesServiceStatus.OK ||
+          !place?.geometry?.location
+        ) {
+          resolve(null);
+          return;
+        }
+        resolve({ lat: place.geometry.location.lat(), lng: place.geometry.location.lng() });
+      });
+    });
+  } catch {
+    return null;
+  }
+}

--- a/src/utils/PlacesUtils.ts
+++ b/src/utils/PlacesUtils.ts
@@ -33,8 +33,8 @@ export interface PlacePrediction {
   _prediction: google.maps.places.PlacePrediction;
 }
 
-// Santander bounding box used for locationBias
-const SANTANDER_BOUNDS: google.maps.LatLngBoundsLiteral = {
+// Santander, Spain bounds for restricting results to this city
+const SANTANDER_RESTRICTION: google.maps.LatLngBoundsLiteral = {
   north: 43.55,
   south: 43.38,
   east: -3.65,
@@ -53,7 +53,7 @@ export async function getPlacePredictions(input: string): Promise<PlacePredictio
 
     const { suggestions } = await AutocompleteSuggestion.fetchAutocompleteSuggestions({
       input,
-      locationBias: SANTANDER_BOUNDS,
+      locationRestriction: SANTANDER_RESTRICTION,
       includedRegionCodes: ["es"],
       language: "es",
       region: "es",

--- a/src/utils/PlacesUtils.ts
+++ b/src/utils/PlacesUtils.ts
@@ -7,15 +7,17 @@ function loadMapsApi(): Promise<void> {
   if (!GOOGLE_MAPS_KEY) return Promise.reject(new Error("No API key"));
 
   loadPromise = new Promise<void>((resolve, reject) => {
-    if ((window as Window & typeof globalThis & { google?: { maps?: unknown } }).google?.maps) {
+    const w = window as Window & typeof globalThis & { google?: { maps?: unknown } };
+    if (w.google?.maps) {
       resolve();
       return;
     }
-    const cb = "__mapsReady";
-    (window as Record<string, unknown>)[cb] = resolve;
     const script = document.createElement("script");
-    script.src = `https://maps.googleapis.com/maps/api/js?key=${GOOGLE_MAPS_KEY}&libraries=places&callback=${cb}&language=es`;
+    // loading=async is the recommended pattern (no callback, no explicit library list)
+    script.src = `https://maps.googleapis.com/maps/api/js?key=${GOOGLE_MAPS_KEY}&loading=async&language=es`;
     script.async = true;
+    script.defer = true;
+    script.onload = () => resolve();
     script.onerror = () => reject(new Error("Failed to load Maps API"));
     document.head.appendChild(script);
   });
@@ -27,71 +29,66 @@ export interface PlacePrediction {
   placeId: string;
   mainText: string;
   secondaryText: string;
+  // Held internally so we can call toPlace() on it without re-fetching
+  _prediction: google.maps.places.PlacePrediction;
 }
 
-let autocompleteService: google.maps.places.AutocompleteService | null = null;
-let placesService: google.maps.places.PlacesService | null = null;
-let placesDiv: HTMLDivElement | null = null;
+// Santander bounding box used for locationBias
+const SANTANDER_BOUNDS: google.maps.LatLngBoundsLiteral = {
+  north: 43.55,
+  south: 43.38,
+  east: -3.65,
+  west: -4.0,
+};
 
 export async function getPlacePredictions(input: string): Promise<PlacePrediction[]> {
   if (!input.trim() || !GOOGLE_MAPS_KEY) return [];
 
   try {
     await loadMapsApi();
-    if (!autocompleteService) {
-      autocompleteService = new google.maps.places.AutocompleteService();
-    }
+    const { AutocompleteSuggestion, AutocompleteSessionToken } =
+      await google.maps.importLibrary("places") as google.maps.PlacesLibrary;
 
-    return new Promise((resolve) => {
-      autocompleteService!.getPlacePredictions(
-        {
-          input,
-          location: new google.maps.LatLng(43.4628, -3.8099),
-          radius: 20000,
-          componentRestrictions: { country: "es" },
-        },
-        (predictions, status) => {
-          if (status !== google.maps.places.PlacesServiceStatus.OK || !predictions) {
-            resolve([]);
-            return;
-          }
-          resolve(
-            predictions.slice(0, 5).map((p) => ({
-              placeId: p.place_id,
-              mainText: p.structured_formatting.main_text,
-              secondaryText: p.structured_formatting.secondary_text ?? "",
-            }))
-          );
-        }
-      );
+    const sessionToken = new AutocompleteSessionToken();
+
+    const { suggestions } = await AutocompleteSuggestion.fetchAutocompleteSuggestions({
+      input,
+      locationBias: SANTANDER_BOUNDS,
+      includedRegionCodes: ["es"],
+      language: "es",
+      region: "es",
+      sessionToken,
     });
+
+    return suggestions
+      .filter((s) => s.placePrediction !== null)
+      .slice(0, 5)
+      .map((s) => {
+        const pred = s.placePrediction!;
+        return {
+          placeId: pred.placeId,
+          mainText: pred.mainText.text,
+          secondaryText: pred.secondaryText?.text ?? "",
+          _prediction: pred,
+        };
+      });
   } catch {
     return [];
   }
 }
 
 export async function getPlaceCoordinates(
-  placeId: string
+  prediction: PlacePrediction
 ): Promise<{ lat: number; lng: number } | null> {
   try {
     await loadMapsApi();
-    if (!placesDiv) placesDiv = document.createElement("div");
-    if (!placesService) {
-      placesService = new google.maps.places.PlacesService(placesDiv);
-    }
+    await google.maps.importLibrary("places");
 
-    return new Promise((resolve) => {
-      placesService!.getDetails({ placeId, fields: ["geometry"] }, (place, status) => {
-        if (
-          status !== google.maps.places.PlacesServiceStatus.OK ||
-          !place?.geometry?.location
-        ) {
-          resolve(null);
-          return;
-        }
-        resolve({ lat: place.geometry.location.lat(), lng: place.geometry.location.lng() });
-      });
-    });
+    const place = prediction._prediction.toPlace();
+    await place.fetchFields({ fields: ["location"] });
+
+    if (!place.location) return null;
+    return { lat: place.location.lat(), lng: place.location.lng() };
   } catch {
     return null;
   }

--- a/src/utils/StopUtils.ts
+++ b/src/utils/StopUtils.ts
@@ -1,0 +1,51 @@
+import type { StopTuple, StopsData } from "../types/stops";
+
+const WALKING_SPEED_MPS = 1.39; // 5 km/h
+
+function haversineMeters(lat1: number, lng1: number, lat2: number, lng2: number): number {
+  const R = 6371000;
+  const dLat = ((lat2 - lat1) * Math.PI) / 180;
+  const dLng = ((lng2 - lng1) * Math.PI) / 180;
+  const a =
+    Math.sin(dLat / 2) ** 2 +
+    Math.cos((lat1 * Math.PI) / 180) *
+      Math.cos((lat2 * Math.PI) / 180) *
+      Math.sin(dLng / 2) ** 2;
+  return R * 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+}
+
+export interface NearestStop {
+  stop: StopTuple;
+  distanceMeters: number;
+  walkingMinutes: number;
+}
+
+export function findNearestStop(lat: number, lng: number, stops: StopsData): NearestStop {
+  let nearest: StopTuple | null = null;
+  let minDist = Infinity;
+
+  for (const key in stops) {
+    const stop = stops[key];
+    const dist = haversineMeters(lat, lng, stop[1], stop[2]);
+    if (dist < minDist) {
+      minDist = dist;
+      nearest = stop;
+    }
+  }
+
+  const stop = nearest ?? (Object.values(stops)[0] as StopTuple);
+  return {
+    stop,
+    distanceMeters: minDist,
+    walkingMinutes: Math.max(1, Math.ceil(minDist / (WALKING_SPEED_MPS * 60))),
+  };
+}
+
+export function distanceMeters(
+  lat1: number,
+  lng1: number,
+  lat2: number,
+  lng2: number
+): number {
+  return haversineMeters(lat1, lng1, lat2, lng2);
+}

--- a/src/views/home/HomeView.tsx
+++ b/src/views/home/HomeView.tsx
@@ -6,6 +6,7 @@ import {
   SUB_VIEW_ID_FAVORITES,
   SUB_VIEW_ID_MAP,
   SUB_VIEW_ID_SEARCH,
+  SUB_VIEW_ID_TRIP,
 } from "../../constants/ViewConstants";
 import type { SubViewId } from "../../types/view";
 
@@ -13,6 +14,7 @@ import Main from "../../components/Main";
 import HomeMenu from "../../components/home/HomeMenu";
 import HomeSearchSubview from "./subviews/HomeSearchSubview";
 import HomeFavoritesSubview from "./subviews/HomeFavoritesSubview";
+import HomeTripSubview from "./subviews/HomeTripSubview";
 
 interface SelectedContentProps {
   subViewId: SubViewId;
@@ -28,6 +30,9 @@ function SelectedContent({ subViewId }: SelectedContentProps): React.JSX.Element
 
     case SUB_VIEW_ID_SEARCH:
       return <HomeSearchSubview />;
+
+    case SUB_VIEW_ID_TRIP:
+      return <HomeTripSubview />;
 
     default:
       throw new Error(

--- a/src/views/home/subviews/HomeTripSubview.module.css
+++ b/src/views/home/subviews/HomeTripSubview.module.css
@@ -1,31 +1,34 @@
-/* ── Layout ── */
-.content {
-  margin: 0 var(--margin-lr);
-  padding-bottom: 120px;
-}
-
-.detailContent {
-  margin: 0 var(--margin-lr);
-  padding-bottom: 120px;
-  padding-top: 8px;
-}
-
-/* ── Search card ── */
-.searchCard {
+/* ── Sticky search (always visible above routes) ── */
+.stickySearch {
+  position: sticky;
+  top: 0;
+  z-index: 8;
+  padding: 0 var(--margin-lr) 12px;
   background: #fff;
-  border-radius: 16px;
-  border: 1px solid rgba(0, 0, 0, 0.1);
-  overflow: visible;
-  margin-bottom: 20px;
 
   @media (prefers-color-scheme: dark) {
-    background: #1c1b20;
-    border-color: rgba(255, 255, 255, 0.1);
+    background: #000;
   }
 }
 
-.searchFields {
-  padding: 4px 0;
+.searchCard {
+  background: #f2f2f7;
+  border-radius: 16px;
+  overflow: visible;
+
+  @media (prefers-color-scheme: dark) {
+    background: #1c1b20;
+  }
+}
+
+/* ── Scrollable content below sticky search ── */
+.content {
+  padding: 0 var(--margin-lr) 120px;
+}
+
+/* ── Detail content (journey steps) ── */
+.detailContent {
+  padding: 8px var(--margin-lr) 120px;
 }
 
 /* ── Input field ── */
@@ -38,16 +41,6 @@
   align-items: center;
   gap: 10px;
   padding: 10px 14px;
-  border-radius: 12px;
-  transition: background-color 0.15s;
-}
-
-.fieldRowFocused {
-  background: rgba(0, 112, 240, 0.04);
-
-  @media (prefers-color-scheme: dark) {
-    background: rgba(0, 112, 240, 0.08);
-  }
 }
 
 .fieldDot {
@@ -100,11 +93,6 @@
   background: #aeaeb2;
   color: #fff;
   flex-shrink: 0;
-  transition: background-color 0.15s;
-
-  &:active {
-    background: #8e8e92;
-  }
 }
 
 .locateBtn {
@@ -114,7 +102,6 @@
   color: var(--color-blue);
   padding: 4px;
   border-radius: 6px;
-  transition: opacity 0.2s;
 }
 
 .locateBtnActive {
@@ -147,15 +134,9 @@
   width: 100%;
   text-align: left;
   border-bottom: 1px solid rgba(0, 0, 0, 0.05);
-  transition: background-color 0.12s;
 
-  &:last-child {
-    border-bottom: 0;
-  }
-
-  &:active {
-    background: rgba(0, 112, 240, 0.07);
-  }
+  &:last-child { border-bottom: 0; }
+  &:active { background: rgba(0, 112, 240, 0.07); }
 
   @media (prefers-color-scheme: dark) {
     border-bottom-color: rgba(255, 255, 255, 0.06);
@@ -183,9 +164,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
 
-  @media (prefers-color-scheme: dark) {
-    color: #fff;
-  }
+  @media (prefers-color-scheme: dark) { color: #fff; }
 }
 
 .dropdownSub {
@@ -196,7 +175,7 @@
   text-overflow: ellipsis;
 }
 
-/* ── Divider + Swap ── */
+/* ── Divider + swap ── */
 .fieldsDivider {
   display: flex;
   align-items: center;
@@ -207,7 +186,7 @@
 .dividerLine {
   flex: 1;
   height: 1px;
-  background: rgba(0, 0, 0, 0.08);
+  background: rgba(0, 0, 0, 0.1);
   margin-left: 20px;
 
   @media (prefers-color-scheme: dark) {
@@ -223,24 +202,21 @@
   height: 28px;
   border-radius: 50%;
   color: var(--color-blue);
-  background: rgba(0, 112, 240, 0.1);
+  background: rgba(0, 112, 240, 0.12);
   flex-shrink: 0;
-  transition: background-color 0.15s, transform 0.2s;
+  transition: transform 0.2s;
 
-  &:active {
-    background: rgba(0, 112, 240, 0.2);
-    transform: rotate(180deg);
-  }
+  &:active { transform: rotate(180deg); }
 }
 
-/* ── Error banner ── */
+/* ── Error ── */
 .errorBanner {
-  background: rgba(255, 59, 48, 0.15);
+  background: rgba(255, 59, 48, 0.12);
   color: #ff3b30;
   border-radius: 10px;
   padding: 10px 14px;
   font-size: 14px;
-  margin-bottom: 16px;
+  margin-bottom: 12px;
 }
 
 /* ── Empty state ── */
@@ -248,13 +224,13 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 56px 20px;
+  padding: 48px 20px;
   text-align: center;
-  color: #aeaeb2;
 }
 
 .emptyIcon {
-  margin-bottom: 16px;
+  color: #aeaeb2;
+  margin-bottom: 14px;
   opacity: 0.4;
 }
 
@@ -283,34 +259,43 @@
   flex-wrap: wrap;
 }
 
-.pill {
+.pillWalk {
   display: flex;
   align-items: center;
-  gap: 5px;
-  padding: 5px 10px;
+  gap: 4px;
+  padding: 4px 9px;
   border-radius: 6px;
   font-size: 12px;
   font-weight: 600;
-  white-space: nowrap;
-
-  &[data-type="walk"] {
-    background: #aeaeb2;
-    color: #fff;
-  }
-
-  &[data-type="bus"] {
-    background: var(--color-blue);
-    color: #fff;
-  }
-
-  &[data-type="transfer"] {
-    background: #ff9500;
-    color: #fff;
-  }
+  background: #aeaeb2;
+  color: #fff;
 }
 
-.pillLine {
+.pillBus {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 9px;
+  border-radius: 6px;
+  font-size: 12px;
   font-weight: 700;
+}
+
+.pillBusDuration {
+  font-weight: 400;
+  opacity: 0.85;
+}
+
+.pillTransfer {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 9px;
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  background: #ff9500;
+  color: #fff;
 }
 
 /* ── Route list ── */
@@ -324,24 +309,15 @@
   display: block;
   width: 100%;
   text-align: left;
-  background: #fff;
+  background: #f2f2f7;
   border-radius: 14px;
-  border: 1px solid rgba(0, 0, 0, 0.08);
   padding: 14px 16px;
-  transition: transform 0.15s, background-color 0.15s;
+  transition: transform 0.15s;
 
-  &:active {
-    transform: scale(0.98);
-    background: rgba(0, 0, 0, 0.02);
-  }
+  &:active { transform: scale(0.98); }
 
   @media (prefers-color-scheme: dark) {
     background: #1c1b20;
-    border-color: rgba(255, 255, 255, 0.08);
-
-    &:active {
-      background: rgba(255, 255, 255, 0.05);
-    }
   }
 }
 
@@ -371,13 +347,10 @@
   font-weight: 700;
   color: #000;
 
-  @media (prefers-color-scheme: dark) {
-    color: #fff;
-  }
+  @media (prefers-color-scheme: dark) { color: #fff; }
 }
 
 .routeTimeSep {
-  font-size: 15px;
   color: #aeaeb2;
 }
 
@@ -386,9 +359,7 @@
   font-weight: 700;
   color: #000;
 
-  @media (prefers-color-scheme: dark) {
-    color: #fff;
-  }
+  @media (prefers-color-scheme: dark) { color: #fff; }
 }
 
 .routeCardRight {
@@ -417,15 +388,13 @@
 
 /* ── Detail summary ── */
 .detailSummary {
-  background: #fff;
+  background: #f2f2f7;
   border-radius: 14px;
-  border: 1px solid rgba(0, 0, 0, 0.08);
   padding: 14px 16px;
   margin-bottom: 16px;
 
   @media (prefers-color-scheme: dark) {
     background: #1c1b20;
-    border-color: rgba(255, 255, 255, 0.08);
   }
 }
 
@@ -433,7 +402,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  margin-bottom: 10px;
+  margin-bottom: 14px;
 }
 
 .detailTimes {
@@ -443,28 +412,23 @@
 }
 
 .detailDep {
-  font-size: 20px;
+  font-size: 22px;
   font-weight: 700;
   color: #000;
 
-  @media (prefers-color-scheme: dark) {
-    color: #fff;
-  }
+  @media (prefers-color-scheme: dark) { color: #fff; }
 }
 
 .detailSep {
   color: #aeaeb2;
-  font-size: 18px;
 }
 
 .detailArr {
-  font-size: 20px;
+  font-size: 22px;
   font-weight: 700;
   color: #000;
 
-  @media (prefers-color-scheme: dark) {
-    color: #fff;
-  }
+  @media (prefers-color-scheme: dark) { color: #fff; }
 }
 
 .detailDuration {
@@ -479,34 +443,59 @@
   font-weight: 600;
 }
 
-.detailRoute {
+/* ── Detail from/to ── */
+.detailPlaces {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+}
+
+.detailPlaceRow {
   display: flex;
   align-items: center;
-  gap: 6px;
-  flex-wrap: wrap;
+  gap: 10px;
 }
 
-.detailRouteIcon {
-  color: #aeaeb2;
+.detailPlaceConnector {
+  width: 2px;
+  height: 10px;
+  background: rgba(0, 0, 0, 0.15);
+  margin-left: 4px;
+
+  @media (prefers-color-scheme: dark) {
+    background: rgba(255, 255, 255, 0.2);
+  }
+}
+
+.detailDot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
   flex-shrink: 0;
+
+  &[data-type="origin"] { background: var(--color-blue); }
+  &[data-type="destination"] { background: #ff3b30; }
 }
 
-.detailFromName {
-  font-size: 13px;
-  color: #636366;
-
-  @media (prefers-color-scheme: dark) {
-    color: #aeaeb2;
-  }
+.detailPlaceText {
+  display: flex;
+  flex-direction: column;
 }
 
-.detailToName {
-  font-size: 13px;
-  color: #636366;
+.detailPlaceLabel {
+  font-size: 11px;
+  font-weight: 600;
+  color: #aeaeb2;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
 
-  @media (prefers-color-scheme: dark) {
-    color: #aeaeb2;
-  }
+.detailPlaceName {
+  font-size: 14px;
+  font-weight: 500;
+  color: #000;
+
+  @media (prefers-color-scheme: dark) { color: #fff; }
 }
 
 /* ── Steps timeline ── */
@@ -517,7 +506,6 @@
 
 .step {
   display: flex;
-  gap: 0;
 }
 
 .stepTimeline {
@@ -536,17 +524,9 @@
   margin-top: 14px;
   z-index: 1;
 
-  &[data-type="walk"] {
-    background: #aeaeb2;
-  }
-
-  &[data-type="bus"] {
-    background: var(--color-blue);
-  }
-
-  &[data-type="transfer"] {
-    background: #ff9500;
-  }
+  &[data-type="walk"] { background: #aeaeb2; }
+  &[data-type="bus"] { background: var(--color-blue); }
+  &[data-type="transfer"] { background: #ff9500; }
 }
 
 .stepLine {
@@ -556,23 +536,17 @@
   margin: 2px 0;
 
   &[data-type="walk"] {
-    background: rgba(174, 174, 178, 0.4);
     background-image: repeating-linear-gradient(
       to bottom,
-      rgba(174, 174, 178, 0.6) 0px,
-      rgba(174, 174, 178, 0.6) 4px,
+      #aeaeb2 0px,
+      #aeaeb2 4px,
       transparent 4px,
       transparent 8px
     );
   }
 
-  &[data-type="bus"] {
-    background: rgba(0, 112, 240, 0.4);
-  }
-
-  &[data-type="transfer"] {
-    background: rgba(255, 149, 0, 0.4);
-  }
+  &[data-type="bus"] { background: rgba(0, 112, 240, 0.5); }
+  &[data-type="transfer"] { background: rgba(255, 149, 0, 0.5); }
 }
 
 .stepBody {
@@ -582,50 +556,55 @@
   min-width: 0;
 }
 
+/* ── Step cards ── */
 .stepCard {
-  display: flex;
-  background: #fff;
+  background: #f2f2f7;
   border-radius: 12px;
-  border: 1px solid rgba(0, 0, 0, 0.08);
-  padding: 12px;
+  overflow: hidden;
 
   @media (prefers-color-scheme: dark) {
     background: #1c1b20;
-    border-color: rgba(255, 255, 255, 0.08);
-  }
-
-  &[data-type="walk"] {
-    border-left: 3px solid #aeaeb2;
-  }
-
-  &[data-type="bus"] {
-    border-left: 3px solid var(--color-blue);
-  }
-
-  &[data-type="transfer"] {
-    border-left: 3px solid #ff9500;
   }
 }
 
-.stepCardContent {
-  flex: 1;
-  min-width: 0;
+.stepCardAccent {
+  height: 4px;
+
+  &[data-type="walk"] { background: #aeaeb2; }
+  &[data-type="transfer"] { background: #ff9500; }
 }
 
-.stepCardTitleRow {
+.stepCardBusHeader {
   display: flex;
   align-items: center;
   gap: 8px;
+  padding: 10px 14px;
+}
+
+.stepCardBusNumber {
+  font-size: 18px;
+  font-weight: 700;
+  letter-spacing: -0.3px;
+}
+
+.stepCardContent {
+  padding: 10px 14px 12px;
+}
+
+.stepWalkHeader {
+  display: flex;
+  align-items: center;
+  gap: 6px;
   margin-bottom: 4px;
 }
 
-.lineBadge {
-  background: var(--color-blue);
-  color: #fff;
-  border-radius: 5px;
-  padding: 3px 8px;
-  font-size: 12px;
-  font-weight: 700;
+.stepWalkIcon {
+  color: #636366;
+  flex-shrink: 0;
+}
+
+.stepTransferIcon {
+  color: #ff9500;
   flex-shrink: 0;
 }
 
@@ -633,11 +612,8 @@
   font-size: 15px;
   font-weight: 600;
   color: #000;
-  margin-bottom: 4px;
 
-  @media (prefers-color-scheme: dark) {
-    color: #fff;
-  }
+  @media (prefers-color-scheme: dark) { color: #fff; }
 }
 
 .stepCardSub {
@@ -650,14 +626,10 @@
     color: #000;
     font-weight: 600;
 
-    @media (prefers-color-scheme: dark) {
-      color: #fff;
-    }
+    @media (prefers-color-scheme: dark) { color: #fff; }
   }
 
-  @media (prefers-color-scheme: dark) {
-    color: #aeaeb2;
-  }
+  @media (prefers-color-scheme: dark) { color: #aeaeb2; }
 }
 
 .stepCardTime {
@@ -667,12 +639,20 @@
   margin-top: 6px;
 }
 
-/* ── Arrival row ── */
+/* ── Arrive row ── */
 .arriveRow {
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 12px 0 0 40px;
+  padding: 12px 0 0 10px;
+}
+
+.arriveDot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #34c759;
+  flex-shrink: 0;
 }
 
 .arriveLabel {

--- a/src/views/home/subviews/HomeTripSubview.module.css
+++ b/src/views/home/subviews/HomeTripSubview.module.css
@@ -20,12 +20,15 @@
 
 /* ── Scrollable content (extra bottom clearance for fixed search + menu) ── */
 .content {
+  display: flex;
+  flex-direction: column;
+  min-height: calc(100svh - 100px);
   padding: 0 var(--margin-lr) calc(env(safe-area-inset-bottom) + 240px);
 }
 
 /* ── Detail content (journey steps) ── */
 .detailContent {
-  padding: 8px var(--margin-lr) 120px;
+  padding: 72px var(--margin-lr) 120px;
 }
 
 /* ── Input field ── */
@@ -37,7 +40,7 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 7px 14px;
+  padding: 12px 14px;
 }
 
 .fieldDot {
@@ -219,10 +222,12 @@
 
 /* ── Empty state ── */
 .emptyState {
+  flex: 1;
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding: 48px 20px;
+  justify-content: center;
+  padding: 20px;
   text-align: center;
 }
 

--- a/src/views/home/subviews/HomeTripSubview.module.css
+++ b/src/views/home/subviews/HomeTripSubview.module.css
@@ -587,6 +587,13 @@
   letter-spacing: -0.3px;
 }
 
+.stepCardBusDestination {
+  font-size: 13px;
+  font-weight: 400;
+  margin-left: auto;
+  opacity: 0.9;
+}
+
 .stepCardContent {
   padding: 10px 14px 12px;
 }

--- a/src/views/home/subviews/HomeTripSubview.module.css
+++ b/src/views/home/subviews/HomeTripSubview.module.css
@@ -14,13 +14,13 @@
 .searchCard {
   background: #fff;
   border-radius: 16px;
-  box-shadow: 0 2px 18px rgba(0, 0, 0, 0.08);
+  border: 1px solid rgba(0, 0, 0, 0.1);
   overflow: visible;
   margin-bottom: 20px;
 
   @media (prefers-color-scheme: dark) {
     background: #1c1b20;
-    box-shadow: 0 2px 18px rgba(0, 0, 0, 0.4);
+    border-color: rgba(255, 255, 255, 0.1);
   }
 }
 
@@ -58,12 +58,10 @@
 
   &[data-type="origin"] {
     background: var(--color-blue);
-    box-shadow: 0 0 0 2px rgba(0, 112, 240, 0.2);
   }
 
   &[data-type="destination"] {
     background: #ff3b30;
-    box-shadow: 0 0 0 2px rgba(255, 59, 48, 0.2);
   }
 }
 
@@ -131,13 +129,13 @@
   right: 0;
   background: #fff;
   border-radius: 12px;
-  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.14);
+  border: 1px solid rgba(0, 0, 0, 0.1);
   z-index: 50;
   overflow: hidden;
 
   @media (prefers-color-scheme: dark) {
     background: #2c2c2e;
-    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.5);
+    border-color: rgba(255, 255, 255, 0.1);
   }
 }
 
@@ -237,7 +235,7 @@
 
 /* ── Error banner ── */
 .errorBanner {
-  background: rgba(255, 59, 48, 0.1);
+  background: rgba(255, 59, 48, 0.15);
   color: #ff3b30;
   border-radius: 10px;
   padding: 10px 14px;
@@ -281,37 +279,33 @@
 .pills {
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 6px;
   flex-wrap: wrap;
 }
 
 .pill {
   display: flex;
   align-items: center;
-  gap: 4px;
-  padding: 3px 8px;
-  border-radius: 20px;
+  gap: 5px;
+  padding: 5px 10px;
+  border-radius: 6px;
   font-size: 12px;
   font-weight: 600;
+  white-space: nowrap;
 
   &[data-type="walk"] {
-    background: rgba(142, 142, 147, 0.15);
-    color: #636366;
-
-    @media (prefers-color-scheme: dark) {
-      background: rgba(142, 142, 147, 0.2);
-      color: #aeaeb2;
-    }
+    background: #aeaeb2;
+    color: #fff;
   }
 
   &[data-type="bus"] {
-    background: rgba(0, 112, 240, 0.12);
-    color: var(--color-blue);
+    background: var(--color-blue);
+    color: #fff;
   }
 
   &[data-type="transfer"] {
-    background: rgba(255, 149, 0, 0.12);
-    color: #ff9500;
+    background: #ff9500;
+    color: #fff;
   }
 }
 
@@ -332,18 +326,22 @@
   text-align: left;
   background: #fff;
   border-radius: 14px;
-  box-shadow: 0 1px 12px rgba(0, 0, 0, 0.07);
+  border: 1px solid rgba(0, 0, 0, 0.08);
   padding: 14px 16px;
-  transition: transform 0.15s, box-shadow 0.15s;
+  transition: transform 0.15s, background-color 0.15s;
 
   &:active {
     transform: scale(0.98);
-    box-shadow: 0 1px 6px rgba(0, 0, 0, 0.05);
+    background: rgba(0, 0, 0, 0.02);
   }
 
   @media (prefers-color-scheme: dark) {
     background: #1c1b20;
-    box-shadow: 0 1px 12px rgba(0, 0, 0, 0.4);
+    border-color: rgba(255, 255, 255, 0.08);
+
+    &:active {
+      background: rgba(255, 255, 255, 0.05);
+    }
   }
 }
 
@@ -403,13 +401,14 @@
 .routeDuration {
   display: flex;
   align-items: center;
-  gap: 4px;
-  background: rgba(0, 112, 240, 0.1);
-  color: var(--color-blue);
+  gap: 5px;
+  background: var(--color-blue);
+  color: #fff;
   border-radius: 8px;
-  padding: 4px 9px;
+  padding: 5px 10px;
   font-size: 13px;
   font-weight: 600;
+  white-space: nowrap;
 }
 
 .routeChevron {
@@ -420,13 +419,13 @@
 .detailSummary {
   background: #fff;
   border-radius: 14px;
+  border: 1px solid rgba(0, 0, 0, 0.08);
   padding: 14px 16px;
   margin-bottom: 16px;
-  box-shadow: 0 1px 12px rgba(0, 0, 0, 0.07);
 
   @media (prefers-color-scheme: dark) {
     background: #1c1b20;
-    box-shadow: 0 1px 12px rgba(0, 0, 0, 0.4);
+    border-color: rgba(255, 255, 255, 0.08);
   }
 }
 
@@ -472,8 +471,8 @@
   display: flex;
   align-items: center;
   gap: 5px;
-  background: rgba(0, 112, 240, 0.1);
-  color: var(--color-blue);
+  background: var(--color-blue);
+  color: #fff;
   border-radius: 8px;
   padding: 5px 10px;
   font-size: 13px;
@@ -538,7 +537,7 @@
   z-index: 1;
 
   &[data-type="walk"] {
-    background: #636366;
+    background: #aeaeb2;
   }
 
   &[data-type="bus"] {
@@ -557,11 +556,11 @@
   margin: 2px 0;
 
   &[data-type="walk"] {
-    background: rgba(99, 99, 102, 0.3);
+    background: rgba(174, 174, 178, 0.4);
     background-image: repeating-linear-gradient(
       to bottom,
-      rgba(99, 99, 102, 0.5) 0px,
-      rgba(99, 99, 102, 0.5) 4px,
+      rgba(174, 174, 178, 0.6) 0px,
+      rgba(174, 174, 178, 0.6) 4px,
       transparent 4px,
       transparent 8px
     );
@@ -585,40 +584,26 @@
 
 .stepCard {
   display: flex;
-  gap: 12px;
   background: #fff;
   border-radius: 12px;
+  border: 1px solid rgba(0, 0, 0, 0.08);
   padding: 12px;
-  box-shadow: 0 1px 8px rgba(0, 0, 0, 0.06);
 
   @media (prefers-color-scheme: dark) {
     background: #1c1b20;
-    box-shadow: 0 1px 8px rgba(0, 0, 0, 0.35);
+    border-color: rgba(255, 255, 255, 0.08);
   }
-}
-
-.stepCardIcon {
-  width: 32px;
-  height: 32px;
-  border-radius: 8px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  flex-shrink: 0;
 
   &[data-type="walk"] {
-    background: rgba(142, 142, 147, 0.15);
-    color: #636366;
+    border-left: 3px solid #aeaeb2;
   }
 
   &[data-type="bus"] {
-    background: rgba(0, 112, 240, 0.12);
-    color: var(--color-blue);
+    border-left: 3px solid var(--color-blue);
   }
 
   &[data-type="transfer"] {
-    background: rgba(255, 149, 0, 0.12);
-    color: #ff9500;
+    border-left: 3px solid #ff9500;
   }
 }
 
@@ -638,7 +623,7 @@
   background: var(--color-blue);
   color: #fff;
   border-radius: 5px;
-  padding: 2px 7px;
+  padding: 3px 8px;
   font-size: 12px;
   font-weight: 700;
   flex-shrink: 0;
@@ -658,7 +643,8 @@
 .stepCardSub {
   font-size: 13px;
   color: #636366;
-  margin-bottom: 2px;
+  margin-bottom: 4px;
+  line-height: 1.4;
 
   strong {
     color: #000;
@@ -675,10 +661,10 @@
 }
 
 .stepCardTime {
-  font-size: 12px;
+  font-size: 13px;
   color: var(--color-blue);
   font-weight: 600;
-  margin-top: 4px;
+  margin-top: 6px;
 }
 
 /* ── Arrival row ── */
@@ -687,10 +673,6 @@
   align-items: center;
   gap: 10px;
   padding: 12px 0 0 40px;
-}
-
-.arriveIcon {
-  color: #34c759;
 }
 
 .arriveLabel {

--- a/src/views/home/subviews/HomeTripSubview.module.css
+++ b/src/views/home/subviews/HomeTripSubview.module.css
@@ -1,14 +1,11 @@
-/* ── Sticky search (always visible above routes) ── */
+/* ── Search card fixed above the home menu ── */
 .stickySearch {
-  position: sticky;
-  top: 0;
+  position: fixed;
+  bottom: calc(env(safe-area-inset-bottom) + 120px);
+  left: 0;
+  right: 0;
   z-index: 8;
-  padding: 0 var(--margin-lr) 12px;
-  background: #fff;
-
-  @media (prefers-color-scheme: dark) {
-    background: #000;
-  }
+  padding: 0 var(--margin-lr);
 }
 
 .searchCard {
@@ -21,9 +18,9 @@
   }
 }
 
-/* ── Scrollable content below sticky search ── */
+/* ── Scrollable content (extra bottom clearance for fixed search + menu) ── */
 .content {
-  padding: 0 var(--margin-lr) 120px;
+  padding: 0 var(--margin-lr) calc(env(safe-area-inset-bottom) + 240px);
 }
 
 /* ── Detail content (journey steps) ── */
@@ -40,7 +37,7 @@
   display: flex;
   align-items: center;
   gap: 10px;
-  padding: 10px 14px;
+  padding: 7px 14px;
 }
 
 .fieldDot {
@@ -111,7 +108,8 @@
 /* ── Dropdown ── */
 .dropdown {
   position: absolute;
-  top: calc(100% + 4px);
+  bottom: calc(100% + 4px);
+  top: auto;
   left: 0;
   right: 0;
   background: #fff;
@@ -561,6 +559,7 @@
   background: #f2f2f7;
   border-radius: 12px;
   overflow: hidden;
+  display: flex;
 
   @media (prefers-color-scheme: dark) {
     background: #1c1b20;
@@ -568,30 +567,12 @@
 }
 
 .stepCardAccent {
-  height: 4px;
+  width: 4px;
+  flex-shrink: 0;
+  align-self: stretch;
 
   &[data-type="walk"] { background: #aeaeb2; }
   &[data-type="transfer"] { background: #ff9500; }
-}
-
-.stepCardBusHeader {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 10px 14px;
-}
-
-.stepCardBusNumber {
-  font-size: 18px;
-  font-weight: 700;
-  letter-spacing: -0.3px;
-}
-
-.stepCardBusDestination {
-  font-size: 13px;
-  font-weight: 400;
-  margin-left: auto;
-  opacity: 0.9;
 }
 
 .stepCardContent {

--- a/src/views/home/subviews/HomeTripSubview.module.css
+++ b/src/views/home/subviews/HomeTripSubview.module.css
@@ -1,0 +1,442 @@
+.content {
+  margin: 0 var(--margin-lr);
+  padding-bottom: 16px;
+}
+
+.searchContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  margin-bottom: 24px;
+}
+
+.inputGroup {
+  position: relative;
+}
+
+.inputWrapper {
+  position: relative;
+  height: 36px;
+}
+
+.icon {
+  color: #8e8e92;
+  position: absolute;
+  z-index: 2;
+  top: 50%;
+  left: 10px;
+  transform: translateY(-50%);
+  pointer-events: none;
+}
+
+.input {
+  background: #f1f1f2;
+  outline: none;
+  border: 0;
+  width: 100%;
+  box-sizing: border-box;
+  font-size: 17px;
+  line-height: normal;
+  padding: 8px 10px;
+  color: #333;
+  text-indent: 20px;
+  cursor: default;
+  border-radius: 8px;
+  position: relative;
+  z-index: 1;
+  transition: background-color 0.2s ease-in-out;
+
+  &:focus {
+    background: #e8e8e8;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    background: #1c1b20;
+    color: rgba(255, 255, 255, 0.8);
+
+    &:focus {
+      background: #2a2a2f;
+    }
+  }
+}
+
+.results {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  background: #fff;
+  border-radius: 8px;
+  overflow: hidden;
+  margin-top: 8px;
+  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.12);
+  z-index: 10;
+
+  @media (prefers-color-scheme: dark) {
+    background: #1c1b20;
+    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+  }
+}
+
+.resultItem {
+  padding: 12px 12px;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.04);
+  width: 100%;
+  text-align: left;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  cursor: pointer;
+  transition: background-color 0.15s ease-in-out;
+  background: transparent;
+  border: 0;
+  font-size: 15px;
+  color: var(--color-blue);
+
+  &:last-child {
+    border-bottom: 0;
+  }
+
+  &:active {
+    background: rgba(0, 112, 240, 0.1);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    color: var(--color-blue);
+    border-bottom-color: rgba(255, 255, 255, 0.1);
+  }
+}
+
+.resultIcon {
+  flex-shrink: 0;
+  color: #8e8e92;
+}
+
+.routesContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.routeCard {
+  background: #fff;
+  border-radius: 12px;
+  padding: 16px;
+  cursor: pointer;
+  transition: all 0.2s ease-in-out;
+  border: 1px solid rgba(0, 0, 0, 0.06);
+
+  &:active {
+    background: #f5f5f7;
+    transform: scale(0.98);
+  }
+
+  @media (prefers-color-scheme: dark) {
+    background: #1c1b20;
+    border-color: rgba(255, 255, 255, 0.1);
+
+    &:active {
+      background: #2a2a2f;
+    }
+  }
+}
+
+.routeHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.routeTime {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  flex: 1;
+}
+
+.departure {
+  font-size: 17px;
+  font-weight: 600;
+  color: #000;
+
+  @media (prefers-color-scheme: dark) {
+    color: #fff;
+  }
+}
+
+.durationBadge {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  padding: 4px 10px;
+  background: rgba(0, 112, 240, 0.1);
+  border-radius: 6px;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-blue);
+  white-space: nowrap;
+}
+
+.arrival {
+  font-size: 17px;
+  font-weight: 600;
+  color: #000;
+
+  @media (prefers-color-scheme: dark) {
+    color: #fff;
+  }
+}
+
+.arrowIcon {
+  color: #8e8e92;
+  flex-shrink: 0;
+}
+
+.routeDetails {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: #8e8e92;
+}
+
+.directRoute,
+.transferRoute {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.emptyState {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 60px 20px;
+  text-align: center;
+  color: #8e8e92;
+}
+
+.emptyIcon {
+  margin-bottom: 16px;
+  opacity: 0.5;
+}
+
+.noResults {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 40px 20px;
+  text-align: center;
+  color: #8e8e92;
+  background: #f5f5f7;
+  border-radius: 12px;
+
+  @media (prefers-color-scheme: dark) {
+    background: #1c1b20;
+  }
+}
+
+.noResultsIcon {
+  margin-bottom: 12px;
+}
+
+.routeDetail {
+  padding-top: 8px;
+}
+
+.backButton {
+  background: transparent;
+  border: 0;
+  color: var(--color-blue);
+  font-size: 15px;
+  font-weight: 600;
+  padding: 8px 0;
+  cursor: pointer;
+  margin-bottom: 16px;
+  transition: color 0.2s ease-in-out;
+
+  &:active {
+    color: #0051d5;
+  }
+}
+
+.routeDetailHeader {
+  background: #fff;
+  border-radius: 12px;
+  padding: 16px;
+  margin-bottom: 20px;
+  border: 1px solid rgba(0, 0, 0, 0.06);
+
+  @media (prefers-color-scheme: dark) {
+    background: #1c1b20;
+    border-color: rgba(255, 255, 255, 0.1);
+  }
+}
+
+.routeTimeDetail {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+.departureDetail {
+  font-size: 17px;
+  font-weight: 600;
+  color: #000;
+
+  @media (prefers-color-scheme: dark) {
+    color: #fff;
+  }
+}
+
+.durationBadgeDetail {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  background: rgba(0, 112, 240, 0.1);
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--color-blue);
+}
+
+.arrivalDetail {
+  font-size: 17px;
+  font-weight: 600;
+  color: #000;
+
+  @media (prefers-color-scheme: dark) {
+    color: #fff;
+  }
+}
+
+.stepsContainer {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.stepCard {
+  background: #fff;
+  border-radius: 12px;
+  padding: 16px;
+  display: flex;
+  gap: 16px;
+  border: 1px solid rgba(0, 0, 0, 0.06);
+
+  @media (prefers-color-scheme: dark) {
+    background: #1c1b20;
+    border-color: rgba(255, 255, 255, 0.1);
+  }
+}
+
+.stepIcon {
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  width: 40px;
+  min-width: 40px;
+  height: 40px;
+  border-radius: 8px;
+  background: rgba(0, 112, 240, 0.1);
+  font-size: 20px;
+  line-height: 40px;
+  text-align: center;
+}
+
+.walkIcon {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.busIcon {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-blue);
+}
+
+.transferIcon {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--color-blue);
+  font-weight: bold;
+}
+
+.stepContent {
+  flex: 1;
+}
+
+.stepTitle {
+  font-size: 15px;
+  font-weight: 600;
+  color: #000;
+  margin-bottom: 6px;
+
+  @media (prefers-color-scheme: dark) {
+    color: #fff;
+  }
+}
+
+.busLineBadge {
+  display: inline-block;
+  background: rgba(0, 112, 240, 0.2);
+  color: var(--color-blue);
+  padding: 3px 8px;
+  border-radius: 4px;
+  font-size: 12px;
+  font-weight: 700;
+  margin-bottom: 8px;
+}
+
+.stepDescription {
+  font-size: 13px;
+  color: #8e8e92;
+  margin-bottom: 8px;
+}
+
+.stopInfo {
+  background: rgba(0, 0, 0, 0.02);
+  border-radius: 8px;
+  padding: 8px;
+  margin-bottom: 8px;
+  font-size: 12px;
+
+  @media (prefers-color-scheme: dark) {
+    background: rgba(255, 255, 255, 0.05);
+  }
+}
+
+.fromStop {
+  font-weight: 600;
+  color: #000;
+  margin-bottom: 4px;
+
+  @media (prefers-color-scheme: dark) {
+    color: rgba(255, 255, 255, 0.9);
+  }
+}
+
+.toStop {
+  color: #8e8e92;
+  font-size: 12px;
+}
+
+.stepDuration {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-blue);
+}

--- a/src/views/home/subviews/HomeTripSubview.module.css
+++ b/src/views/home/subviews/HomeTripSubview.module.css
@@ -1,442 +1,700 @@
+/* ── Layout ── */
 .content {
   margin: 0 var(--margin-lr);
-  padding-bottom: 16px;
+  padding-bottom: 120px;
 }
 
-.searchContainer {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-  margin-bottom: 24px;
+.detailContent {
+  margin: 0 var(--margin-lr);
+  padding-bottom: 120px;
+  padding-top: 8px;
 }
 
-.inputGroup {
-  position: relative;
-}
-
-.inputWrapper {
-  position: relative;
-  height: 36px;
-}
-
-.icon {
-  color: #8e8e92;
-  position: absolute;
-  z-index: 2;
-  top: 50%;
-  left: 10px;
-  transform: translateY(-50%);
-  pointer-events: none;
-}
-
-.input {
-  background: #f1f1f2;
-  outline: none;
-  border: 0;
-  width: 100%;
-  box-sizing: border-box;
-  font-size: 17px;
-  line-height: normal;
-  padding: 8px 10px;
-  color: #333;
-  text-indent: 20px;
-  cursor: default;
-  border-radius: 8px;
-  position: relative;
-  z-index: 1;
-  transition: background-color 0.2s ease-in-out;
-
-  &:focus {
-    background: #e8e8e8;
-  }
-
-  @media (prefers-color-scheme: dark) {
-    background: #1c1b20;
-    color: rgba(255, 255, 255, 0.8);
-
-    &:focus {
-      background: #2a2a2f;
-    }
-  }
-}
-
-.results {
-  position: absolute;
-  top: 100%;
-  left: 0;
-  right: 0;
+/* ── Search card ── */
+.searchCard {
   background: #fff;
-  border-radius: 8px;
-  overflow: hidden;
-  margin-top: 8px;
-  box-shadow: 0 10px 30px rgba(0, 0, 0, 0.12);
-  z-index: 10;
+  border-radius: 16px;
+  box-shadow: 0 2px 18px rgba(0, 0, 0, 0.08);
+  overflow: visible;
+  margin-bottom: 20px;
 
   @media (prefers-color-scheme: dark) {
     background: #1c1b20;
-    box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+    box-shadow: 0 2px 18px rgba(0, 0, 0, 0.4);
   }
 }
 
-.resultItem {
-  padding: 12px 12px;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.04);
-  width: 100%;
-  text-align: left;
+.searchFields {
+  padding: 4px 0;
+}
+
+/* ── Input field ── */
+.fieldGroup {
+  position: relative;
+}
+
+.fieldRow {
   display: flex;
   align-items: center;
   gap: 10px;
-  cursor: pointer;
-  transition: background-color 0.15s ease-in-out;
-  background: transparent;
+  padding: 10px 14px;
+  border-radius: 12px;
+  transition: background-color 0.15s;
+}
+
+.fieldRowFocused {
+  background: rgba(0, 112, 240, 0.04);
+
+  @media (prefers-color-scheme: dark) {
+    background: rgba(0, 112, 240, 0.08);
+  }
+}
+
+.fieldDot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  flex-shrink: 0;
+
+  &[data-type="origin"] {
+    background: var(--color-blue);
+    box-shadow: 0 0 0 2px rgba(0, 112, 240, 0.2);
+  }
+
+  &[data-type="destination"] {
+    background: #ff3b30;
+    box-shadow: 0 0 0 2px rgba(255, 59, 48, 0.2);
+  }
+}
+
+.fieldInput {
+  flex: 1;
   border: 0;
-  font-size: 15px;
+  outline: none;
+  background: transparent;
+  font-size: 16px;
+  color: #000;
+  min-width: 0;
+
+  &::placeholder {
+    color: #aeaeb2;
+  }
+
+  @media (prefers-color-scheme: dark) {
+    color: #fff;
+  }
+}
+
+.fieldActions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  flex-shrink: 0;
+}
+
+.clearBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: #aeaeb2;
+  color: #fff;
+  flex-shrink: 0;
+  transition: background-color 0.15s;
+
+  &:active {
+    background: #8e8e92;
+  }
+}
+
+.locateBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
   color: var(--color-blue);
+  padding: 4px;
+  border-radius: 6px;
+  transition: opacity 0.2s;
+}
+
+.locateBtnActive {
+  opacity: 0.5;
+}
+
+/* ── Dropdown ── */
+.dropdown {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 8px 30px rgba(0, 0, 0, 0.14);
+  z-index: 50;
+  overflow: hidden;
+
+  @media (prefers-color-scheme: dark) {
+    background: #2c2c2e;
+    box-shadow: 0 8px 30px rgba(0, 0, 0, 0.5);
+  }
+}
+
+.dropdownItem {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 11px 14px;
+  width: 100%;
+  text-align: left;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.05);
+  transition: background-color 0.12s;
 
   &:last-child {
     border-bottom: 0;
   }
 
   &:active {
-    background: rgba(0, 112, 240, 0.1);
+    background: rgba(0, 112, 240, 0.07);
   }
 
   @media (prefers-color-scheme: dark) {
-    color: var(--color-blue);
-    border-bottom-color: rgba(255, 255, 255, 0.1);
+    border-bottom-color: rgba(255, 255, 255, 0.06);
   }
 }
 
-.resultIcon {
+.dropdownIcon {
+  color: #aeaeb2;
   flex-shrink: 0;
-  color: #8e8e92;
+  margin-top: 2px;
 }
 
-.routesContainer {
+.dropdownText {
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 2px;
+  min-width: 0;
 }
 
-.routeCard {
-  background: #fff;
-  border-radius: 12px;
-  padding: 16px;
-  cursor: pointer;
-  transition: all 0.2s ease-in-out;
-  border: 1px solid rgba(0, 0, 0, 0.06);
+.dropdownMain {
+  font-size: 15px;
+  color: #000;
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+
+  @media (prefers-color-scheme: dark) {
+    color: #fff;
+  }
+}
+
+.dropdownSub {
+  font-size: 12px;
+  color: #aeaeb2;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+/* ── Divider + Swap ── */
+.fieldsDivider {
+  display: flex;
+  align-items: center;
+  padding: 0 14px;
+  gap: 10px;
+}
+
+.dividerLine {
+  flex: 1;
+  height: 1px;
+  background: rgba(0, 0, 0, 0.08);
+  margin-left: 20px;
+
+  @media (prefers-color-scheme: dark) {
+    background: rgba(255, 255, 255, 0.1);
+  }
+}
+
+.swapBtn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  color: var(--color-blue);
+  background: rgba(0, 112, 240, 0.1);
+  flex-shrink: 0;
+  transition: background-color 0.15s, transform 0.2s;
 
   &:active {
-    background: #f5f5f7;
-    transform: scale(0.98);
-  }
-
-  @media (prefers-color-scheme: dark) {
-    background: #1c1b20;
-    border-color: rgba(255, 255, 255, 0.1);
-
-    &:active {
-      background: #2a2a2f;
-    }
+    background: rgba(0, 112, 240, 0.2);
+    transform: rotate(180deg);
   }
 }
 
-.routeHeader {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 12px;
+/* ── Error banner ── */
+.errorBanner {
+  background: rgba(255, 59, 48, 0.1);
+  color: #ff3b30;
+  border-radius: 10px;
+  padding: 10px 14px;
+  font-size: 14px;
+  margin-bottom: 16px;
 }
 
-.routeTime {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  flex: 1;
-}
-
-.departure {
-  font-size: 17px;
-  font-weight: 600;
-  color: #000;
-
-  @media (prefers-color-scheme: dark) {
-    color: #fff;
-  }
-}
-
-.durationBadge {
-  display: flex;
-  align-items: center;
-  gap: 4px;
-  padding: 4px 10px;
-  background: rgba(0, 112, 240, 0.1);
-  border-radius: 6px;
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--color-blue);
-  white-space: nowrap;
-}
-
-.arrival {
-  font-size: 17px;
-  font-weight: 600;
-  color: #000;
-
-  @media (prefers-color-scheme: dark) {
-    color: #fff;
-  }
-}
-
-.arrowIcon {
-  color: #8e8e92;
-  flex-shrink: 0;
-}
-
-.routeDetails {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  font-size: 13px;
-  color: #8e8e92;
-}
-
-.directRoute,
-.transferRoute {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-}
-
+/* ── Empty state ── */
 .emptyState {
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center;
-  padding: 60px 20px;
+  padding: 56px 20px;
   text-align: center;
-  color: #8e8e92;
+  color: #aeaeb2;
 }
 
 .emptyIcon {
   margin-bottom: 16px;
-  opacity: 0.5;
+  opacity: 0.4;
 }
 
-.noResults {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  padding: 40px 20px;
-  text-align: center;
-  color: #8e8e92;
-  background: #f5f5f7;
-  border-radius: 12px;
-
-  @media (prefers-color-scheme: dark) {
-    background: #1c1b20;
-  }
-}
-
-.noResultsIcon {
-  margin-bottom: 12px;
-}
-
-.routeDetail {
-  padding-top: 8px;
-}
-
-.backButton {
-  background: transparent;
-  border: 0;
-  color: var(--color-blue);
-  font-size: 15px;
+.emptyTitle {
+  font-size: 17px;
   font-weight: 600;
-  padding: 8px 0;
-  cursor: pointer;
-  margin-bottom: 16px;
-  transition: color 0.2s ease-in-out;
-
-  &:active {
-    color: #0051d5;
-  }
-}
-
-.routeDetailHeader {
-  background: #fff;
-  border-radius: 12px;
-  padding: 16px;
-  margin-bottom: 20px;
-  border: 1px solid rgba(0, 0, 0, 0.06);
+  color: #3c3c43;
+  margin: 0 0 6px;
 
   @media (prefers-color-scheme: dark) {
-    background: #1c1b20;
-    border-color: rgba(255, 255, 255, 0.1);
+    color: rgba(255, 255, 255, 0.5);
   }
 }
 
-.routeTimeDetail {
+.emptyHint {
+  font-size: 14px;
+  color: #aeaeb2;
+  margin: 0;
+}
+
+/* ── Route pills ── */
+.pills {
   display: flex;
   align-items: center;
-  gap: 16px;
+  gap: 4px;
   flex-wrap: wrap;
 }
 
-.departureDetail {
-  font-size: 17px;
-  font-weight: 600;
-  color: #000;
-
-  @media (prefers-color-scheme: dark) {
-    color: #fff;
-  }
-}
-
-.durationBadgeDetail {
+.pill {
   display: flex;
   align-items: center;
-  gap: 6px;
-  padding: 6px 12px;
-  background: rgba(0, 112, 240, 0.1);
-  border-radius: 8px;
-  font-size: 13px;
+  gap: 4px;
+  padding: 3px 8px;
+  border-radius: 20px;
+  font-size: 12px;
   font-weight: 600;
-  color: var(--color-blue);
-}
 
-.arrivalDetail {
-  font-size: 17px;
-  font-weight: 600;
-  color: #000;
+  &[data-type="walk"] {
+    background: rgba(142, 142, 147, 0.15);
+    color: #636366;
 
-  @media (prefers-color-scheme: dark) {
-    color: #fff;
+    @media (prefers-color-scheme: dark) {
+      background: rgba(142, 142, 147, 0.2);
+      color: #aeaeb2;
+    }
+  }
+
+  &[data-type="bus"] {
+    background: rgba(0, 112, 240, 0.12);
+    color: var(--color-blue);
+  }
+
+  &[data-type="transfer"] {
+    background: rgba(255, 149, 0, 0.12);
+    color: #ff9500;
   }
 }
 
-.stepsContainer {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
+.pillLine {
+  font-weight: 700;
 }
 
-.stepCard {
-  background: #fff;
-  border-radius: 12px;
-  padding: 16px;
+/* ── Route list ── */
+.routesList {
   display: flex;
-  gap: 16px;
-  border: 1px solid rgba(0, 0, 0, 0.06);
+  flex-direction: column;
+  gap: 10px;
+}
+
+.routeCard {
+  display: block;
+  width: 100%;
+  text-align: left;
+  background: #fff;
+  border-radius: 14px;
+  box-shadow: 0 1px 12px rgba(0, 0, 0, 0.07);
+  padding: 14px 16px;
+  transition: transform 0.15s, box-shadow 0.15s;
+
+  &:active {
+    transform: scale(0.98);
+    box-shadow: 0 1px 6px rgba(0, 0, 0, 0.05);
+  }
 
   @media (prefers-color-scheme: dark) {
     background: #1c1b20;
-    border-color: rgba(255, 255, 255, 0.1);
+    box-shadow: 0 1px 12px rgba(0, 0, 0, 0.4);
   }
 }
 
-.stepIcon {
+.routeCardInner {
   display: flex;
-  align-items: flex-start;
-  justify-content: center;
-  width: 40px;
-  min-width: 40px;
-  height: 40px;
-  border-radius: 8px;
-  background: rgba(0, 112, 240, 0.1);
-  font-size: 20px;
-  line-height: 40px;
-  text-align: center;
-}
-
-.walkIcon {
-  width: 100%;
-  height: 100%;
-  display: flex;
+  justify-content: space-between;
   align-items: center;
-  justify-content: center;
+  gap: 12px;
 }
 
-.busIcon {
-  width: 100%;
-  height: 100%;
+.routeCardLeft {
   display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--color-blue);
-}
-
-.transferIcon {
-  width: 100%;
-  height: 100%;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  color: var(--color-blue);
-  font-weight: bold;
-}
-
-.stepContent {
+  flex-direction: column;
+  gap: 8px;
   flex: 1;
+  min-width: 0;
 }
 
-.stepTitle {
-  font-size: 15px;
-  font-weight: 600;
+.routeCardTimes {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.routeDepTime {
+  font-size: 17px;
+  font-weight: 700;
   color: #000;
-  margin-bottom: 6px;
 
   @media (prefers-color-scheme: dark) {
     color: #fff;
   }
 }
 
-.busLineBadge {
-  display: inline-block;
-  background: rgba(0, 112, 240, 0.2);
-  color: var(--color-blue);
-  padding: 3px 8px;
-  border-radius: 4px;
-  font-size: 12px;
+.routeTimeSep {
+  font-size: 15px;
+  color: #aeaeb2;
+}
+
+.routeArrTime {
+  font-size: 17px;
   font-weight: 700;
-  margin-bottom: 8px;
-}
-
-.stepDescription {
-  font-size: 13px;
-  color: #8e8e92;
-  margin-bottom: 8px;
-}
-
-.stopInfo {
-  background: rgba(0, 0, 0, 0.02);
-  border-radius: 8px;
-  padding: 8px;
-  margin-bottom: 8px;
-  font-size: 12px;
+  color: #000;
 
   @media (prefers-color-scheme: dark) {
-    background: rgba(255, 255, 255, 0.05);
+    color: #fff;
   }
 }
 
-.fromStop {
+.routeCardRight {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.routeDuration {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  background: rgba(0, 112, 240, 0.1);
+  color: var(--color-blue);
+  border-radius: 8px;
+  padding: 4px 9px;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.routeChevron {
+  color: #c7c7cc;
+}
+
+/* ── Detail summary ── */
+.detailSummary {
+  background: #fff;
+  border-radius: 14px;
+  padding: 14px 16px;
+  margin-bottom: 16px;
+  box-shadow: 0 1px 12px rgba(0, 0, 0, 0.07);
+
+  @media (prefers-color-scheme: dark) {
+    background: #1c1b20;
+    box-shadow: 0 1px 12px rgba(0, 0, 0, 0.4);
+  }
+}
+
+.detailSummaryRow {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.detailTimes {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.detailDep {
+  font-size: 20px;
+  font-weight: 700;
+  color: #000;
+
+  @media (prefers-color-scheme: dark) {
+    color: #fff;
+  }
+}
+
+.detailSep {
+  color: #aeaeb2;
+  font-size: 18px;
+}
+
+.detailArr {
+  font-size: 20px;
+  font-weight: 700;
+  color: #000;
+
+  @media (prefers-color-scheme: dark) {
+    color: #fff;
+  }
+}
+
+.detailDuration {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  background: rgba(0, 112, 240, 0.1);
+  color: var(--color-blue);
+  border-radius: 8px;
+  padding: 5px 10px;
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.detailRoute {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.detailRouteIcon {
+  color: #aeaeb2;
+  flex-shrink: 0;
+}
+
+.detailFromName {
+  font-size: 13px;
+  color: #636366;
+
+  @media (prefers-color-scheme: dark) {
+    color: #aeaeb2;
+  }
+}
+
+.detailToName {
+  font-size: 13px;
+  color: #636366;
+
+  @media (prefers-color-scheme: dark) {
+    color: #aeaeb2;
+  }
+}
+
+/* ── Steps timeline ── */
+.stepsContainer {
+  display: flex;
+  flex-direction: column;
+}
+
+.step {
+  display: flex;
+  gap: 0;
+}
+
+.stepTimeline {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  width: 32px;
+  flex-shrink: 0;
+}
+
+.stepDot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  margin-top: 14px;
+  z-index: 1;
+
+  &[data-type="walk"] {
+    background: #636366;
+  }
+
+  &[data-type="bus"] {
+    background: var(--color-blue);
+  }
+
+  &[data-type="transfer"] {
+    background: #ff9500;
+  }
+}
+
+.stepLine {
+  width: 2px;
+  flex: 1;
+  min-height: 16px;
+  margin: 2px 0;
+
+  &[data-type="walk"] {
+    background: rgba(99, 99, 102, 0.3);
+    background-image: repeating-linear-gradient(
+      to bottom,
+      rgba(99, 99, 102, 0.5) 0px,
+      rgba(99, 99, 102, 0.5) 4px,
+      transparent 4px,
+      transparent 8px
+    );
+  }
+
+  &[data-type="bus"] {
+    background: rgba(0, 112, 240, 0.4);
+  }
+
+  &[data-type="transfer"] {
+    background: rgba(255, 149, 0, 0.4);
+  }
+}
+
+.stepBody {
+  flex: 1;
+  padding-bottom: 12px;
+  padding-left: 8px;
+  min-width: 0;
+}
+
+.stepCard {
+  display: flex;
+  gap: 12px;
+  background: #fff;
+  border-radius: 12px;
+  padding: 12px;
+  box-shadow: 0 1px 8px rgba(0, 0, 0, 0.06);
+
+  @media (prefers-color-scheme: dark) {
+    background: #1c1b20;
+    box-shadow: 0 1px 8px rgba(0, 0, 0, 0.35);
+  }
+}
+
+.stepCardIcon {
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+
+  &[data-type="walk"] {
+    background: rgba(142, 142, 147, 0.15);
+    color: #636366;
+  }
+
+  &[data-type="bus"] {
+    background: rgba(0, 112, 240, 0.12);
+    color: var(--color-blue);
+  }
+
+  &[data-type="transfer"] {
+    background: rgba(255, 149, 0, 0.12);
+    color: #ff9500;
+  }
+}
+
+.stepCardContent {
+  flex: 1;
+  min-width: 0;
+}
+
+.stepCardTitleRow {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 4px;
+}
+
+.lineBadge {
+  background: var(--color-blue);
+  color: #fff;
+  border-radius: 5px;
+  padding: 2px 7px;
+  font-size: 12px;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+
+.stepCardTitle {
+  font-size: 15px;
   font-weight: 600;
   color: #000;
   margin-bottom: 4px;
 
   @media (prefers-color-scheme: dark) {
-    color: rgba(255, 255, 255, 0.9);
+    color: #fff;
   }
 }
 
-.toStop {
-  color: #8e8e92;
-  font-size: 12px;
+.stepCardSub {
+  font-size: 13px;
+  color: #636366;
+  margin-bottom: 2px;
+
+  strong {
+    color: #000;
+    font-weight: 600;
+
+    @media (prefers-color-scheme: dark) {
+      color: #fff;
+    }
+  }
+
+  @media (prefers-color-scheme: dark) {
+    color: #aeaeb2;
+  }
 }
 
-.stepDuration {
+.stepCardTime {
   font-size: 12px;
-  font-weight: 600;
   color: var(--color-blue);
+  font-weight: 600;
+  margin-top: 4px;
+}
+
+/* ── Arrival row ── */
+.arriveRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 0 0 40px;
+}
+
+.arriveIcon {
+  color: #34c759;
+}
+
+.arriveLabel {
+  font-size: 15px;
+  font-weight: 600;
+  color: #34c759;
 }

--- a/src/views/home/subviews/HomeTripSubview.tsx
+++ b/src/views/home/subviews/HomeTripSubview.tsx
@@ -1,7 +1,7 @@
 import React from "react";
 import type { FormEvent } from "react";
 import { Fragment, useState, useMemo } from "react";
-import { ArrowRightUp, MapPin, Search, Clock, Bus, AlertCircle } from "lucide-react";
+import { ChevronRight, MapPin, Search, Clock, Bus, AlertCircle } from "lucide-react";
 
 import { useI18n } from "../../../contexts/I18nContext";
 import Nav from "../../../components/Nav";
@@ -287,7 +287,7 @@ function HomeTripSubview(): React.JSX.Element {
                           </div>
                           <div className={styles.arrival}>{route.arrivalTime}</div>
                         </div>
-                        <ArrowRightUp size={16} className={styles.arrowIcon} aria-hidden="true" />
+                        <ChevronRight size={16} className={styles.arrowIcon} aria-hidden="true" />
                       </div>
 
                       <div className={styles.routeDetails}>

--- a/src/views/home/subviews/HomeTripSubview.tsx
+++ b/src/views/home/subviews/HomeTripSubview.tsx
@@ -627,7 +627,7 @@ function HomeTripSubview(): React.JSX.Element {
             <Bus size={36} className={styles.emptyIcon} aria-hidden="true" />
             <p className={styles.emptyTitle}>{getText("plan_trip")}</p>
             <p className={styles.emptyHint}>
-              {getText("from")} · {getText("to")}
+              {getText("trip_empty_hint")}
             </p>
           </div>
         )}

--- a/src/views/home/subviews/HomeTripSubview.tsx
+++ b/src/views/home/subviews/HomeTripSubview.tsx
@@ -37,6 +37,7 @@ interface RouteSegment {
   duration: number;
   label: string;
   busLine?: string;
+  busDestination?: string;
   fromStop?: string;
   toStop?: string;
   distanceMeters?: number;
@@ -100,6 +101,7 @@ function buildRoutes(from: SelectedPlace, to: SelectedPlace): RouteOption[] {
           duration: busDurationMin,
           label: "Bus 1",
           busLine: "1",
+          busDestination: "Estación",
           fromStop: from.nearest.stop[3],
           toStop: to.nearest.stop[3],
         },
@@ -130,6 +132,7 @@ function buildRoutes(from: SelectedPlace, to: SelectedPlace): RouteOption[] {
           duration: halfBus,
           label: "Bus 3",
           busLine: "3",
+          busDestination: "Avenida",
           fromStop: from.nearest.stop[3],
           toStop: "Jardines de Pereda",
         },
@@ -143,6 +146,7 @@ function buildRoutes(from: SelectedPlace, to: SelectedPlace): RouteOption[] {
           duration: halfBus,
           label: "Bus 7",
           busLine: "7",
+          busDestination: "Estación",
           fromStop: "Jardines de Pereda",
           toStop: to.nearest.stop[3],
         },
@@ -376,6 +380,11 @@ function StepRow({ segment, isLast }: StepRowProps): React.JSX.Element {
             >
               <Bus size={16} aria-hidden="true" />
               <span className={styles.stepCardBusNumber}>{segment.busLine}</span>
+              {segment.busDestination && (
+                <span className={styles.stepCardBusDestination}>
+                  towards {segment.busDestination}
+                </span>
+              )}
             </div>
             <div className={styles.stepCardContent}>
               <div className={styles.stepCardSub}>

--- a/src/views/home/subviews/HomeTripSubview.tsx
+++ b/src/views/home/subviews/HomeTripSubview.tsx
@@ -420,7 +420,7 @@ function HomeTripSubview(): React.JSX.Element {
   const resolvePlace = async (
     pred: PlacePrediction
   ): Promise<SelectedPlace | null> => {
-    const coords = await getPlaceCoordinates(pred.placeId);
+    const coords = await getPlaceCoordinates(pred);
     if (!coords) return null;
     const nearest = findNearestStop(coords.lat, coords.lng, Stops);
     return { name: pred.mainText, lat: coords.lat, lng: coords.lng, nearest };

--- a/src/views/home/subviews/HomeTripSubview.tsx
+++ b/src/views/home/subviews/HomeTripSubview.tsx
@@ -269,12 +269,12 @@ function RoutePills({ segments }: { segments: RouteSegment[] }): React.JSX.Eleme
     <div className={styles.pills}>
       {segments.map((seg, i) => (
         <div key={i} className={styles.pill} data-type={seg.type}>
-          {seg.type === "walk" && <Footprints size={11} aria-hidden="true" />}
+          {seg.type === "walk" && <span>Walk</span>}
           {seg.type === "bus" && seg.busLine && (
-            <span className={styles.pillLine}>{seg.busLine}</span>
+            <span className={styles.pillLine}>Line {seg.busLine}</span>
           )}
-          {seg.type === "transfer" && <ArrowUpDown size={11} aria-hidden="true" />}
-          <span>{seg.duration}′</span>
+          {seg.type === "transfer" && <span>Transfer</span>}
+          <span>{seg.duration}m</span>
         </div>
       ))}
     </div>
@@ -302,7 +302,7 @@ function RouteCard({ route, onClick }: RouteCardProps): React.JSX.Element {
         <div className={styles.routeCardRight}>
           <div className={styles.routeDuration}>
             <Clock size={12} aria-hidden="true" />
-            <span>{route.totalMinutes}′</span>
+            <span>{route.totalMinutes}m</span>
           </div>
           <ChevronRight size={16} className={styles.routeChevron} aria-hidden="true" />
         </div>
@@ -326,47 +326,37 @@ function StepRow({ segment, isLast }: StepRowProps): React.JSX.Element {
       <div className={styles.stepBody}>
         {segment.type === "walk" && (
           <div className={styles.stepCard} data-type="walk">
-            <div className={styles.stepCardIcon} data-type="walk">
-              <Footprints size={15} aria-hidden="true" />
-            </div>
             <div className={styles.stepCardContent}>
               <div className={styles.stepCardTitle}>
-                Caminar{segment.distanceMeters ? ` ${segment.distanceMeters} m` : ""}
+                Walk{segment.distanceMeters ? ` ${segment.distanceMeters} m` : ""}
               </div>
               <div className={styles.stepCardSub}>{segment.label}</div>
-              <div className={styles.stepCardTime}>{segment.duration} min</div>
+              <div className={styles.stepCardTime}>{segment.duration} minutes</div>
             </div>
           </div>
         )}
         {segment.type === "bus" && (
           <div className={styles.stepCard} data-type="bus">
-            <div className={styles.stepCardIcon} data-type="bus">
-              <Bus size={15} aria-hidden="true" />
-            </div>
             <div className={styles.stepCardContent}>
               <div className={styles.stepCardTitleRow}>
-                <div className={styles.lineBadge}>{segment.busLine}</div>
-                <div className={styles.stepCardTitle}>{segment.label}</div>
+                <div className={styles.lineBadge}>Line {segment.busLine}</div>
               </div>
               <div className={styles.stepCardSub}>
-                Subir en <strong>{segment.fromStop}</strong>
+                Board at <strong>{segment.fromStop}</strong>
               </div>
               <div className={styles.stepCardSub}>
-                Bajar en <strong>{segment.toStop}</strong>
+                Alight at <strong>{segment.toStop}</strong>
               </div>
-              <div className={styles.stepCardTime}>{segment.duration} min</div>
+              <div className={styles.stepCardTime}>{segment.duration} minutes</div>
             </div>
           </div>
         )}
         {segment.type === "transfer" && (
           <div className={styles.stepCard} data-type="transfer">
-            <div className={styles.stepCardIcon} data-type="transfer">
-              <ArrowUpDown size={15} aria-hidden="true" />
-            </div>
             <div className={styles.stepCardContent}>
-              <div className={styles.stepCardTitle}>Transbordo</div>
+              <div className={styles.stepCardTitle}>Transfer</div>
               <div className={styles.stepCardSub}>{segment.label}</div>
-              <div className={styles.stepCardTime}>{segment.duration} min</div>
+              <div className={styles.stepCardTime}>{segment.duration} minutes</div>
             </div>
           </div>
         )}
@@ -478,7 +468,7 @@ function HomeTripSubview(): React.JSX.Element {
   if (selectedRoute) {
     return (
       <Fragment>
-        <Nav isHeader={false} titleText={`${selectedRoute.departure} → ${selectedRoute.arrival}`} />
+        <Nav isHeader titleText={getText("trip")} />
         <div className={styles.detailContent}>
           <div className={styles.detailSummary}>
             <div className={styles.detailSummaryRow}>
@@ -489,7 +479,7 @@ function HomeTripSubview(): React.JSX.Element {
               </div>
               <div className={styles.detailDuration}>
                 <Clock size={13} aria-hidden="true" />
-                {selectedRoute.totalMinutes} min
+                {selectedRoute.totalMinutes} minutes
               </div>
             </div>
             <div className={styles.detailRoute}>
@@ -509,10 +499,7 @@ function HomeTripSubview(): React.JSX.Element {
               />
             ))}
             <div className={styles.arriveRow}>
-              <div className={styles.arriveIcon}>
-                <Navigation2 size={14} aria-hidden="true" />
-              </div>
-              <span className={styles.arriveLabel}>{getText("arrival")}: {selectedRoute.arrival}</span>
+              <span className={styles.arriveLabel}>Arrive at {selectedRoute.arrival}</span>
             </div>
           </div>
         </div>

--- a/src/views/home/subviews/HomeTripSubview.tsx
+++ b/src/views/home/subviews/HomeTripSubview.tsx
@@ -8,8 +8,7 @@ import {
   Bus,
   Footprints,
   ArrowUpDown,
-  CircleDot,
-  Navigation2,
+  ArrowRight,
   ChevronRight,
 } from "lucide-react";
 
@@ -21,6 +20,7 @@ import { getPlacePredictions, getPlaceCoordinates } from "../../../utils/PlacesU
 import type { PlacePrediction } from "../../../utils/PlacesUtils";
 import { findNearestStop } from "../../../utils/StopUtils";
 import type { NearestStop } from "../../../utils/StopUtils";
+import { getLineBackgroundColor, getLineTextColor } from "../../../utils/LineUtils";
 import styles from "./HomeTripSubview.module.css";
 
 const Stops = stopsJson as unknown as StopsData;
@@ -62,7 +62,7 @@ function addMinutes(date: Date, minutes: number): Date {
 
 function buildRoutes(from: SelectedPlace, to: SelectedPlace): RouteOption[] {
   const now = new Date();
-  const busSpeedMps = 5.5; // 20 km/h average urban bus
+  const busSpeedMps = 5.5;
   const fromToStopMeters = from.nearest.distanceMeters;
   const toStopToDestMeters = to.nearest.distanceMeters;
   const stopToStopMeters = Math.sqrt(
@@ -98,7 +98,7 @@ function buildRoutes(from: SelectedPlace, to: SelectedPlace): RouteOption[] {
         {
           type: "bus",
           duration: busDurationMin,
-          label: "Línea 1",
+          label: "Bus 1",
           busLine: "1",
           fromStop: from.nearest.stop[3],
           toStop: to.nearest.stop[3],
@@ -128,7 +128,7 @@ function buildRoutes(from: SelectedPlace, to: SelectedPlace): RouteOption[] {
         {
           type: "bus",
           duration: halfBus,
-          label: "Línea 3",
+          label: "Bus 3",
           busLine: "3",
           fromStop: from.nearest.stop[3],
           toStop: "Jardines de Pereda",
@@ -141,7 +141,7 @@ function buildRoutes(from: SelectedPlace, to: SelectedPlace): RouteOption[] {
         {
           type: "bus",
           duration: halfBus,
-          label: "Línea 7",
+          label: "Bus 7",
           busLine: "7",
           fromStop: "Jardines de Pereda",
           toStop: to.nearest.stop[3],
@@ -168,7 +168,6 @@ interface InputFieldProps {
   onLocation?: () => void;
   isLocating?: boolean;
   dot?: "origin" | "destination";
-  autoFocus?: boolean;
 }
 
 function InputField({
@@ -182,7 +181,6 @@ function InputField({
   onLocation,
   isLocating,
   dot,
-  autoFocus,
 }: InputFieldProps): React.JSX.Element {
   const inputRef = useRef<HTMLInputElement>(null);
   const [focused, setFocused] = useState(false);
@@ -190,7 +188,7 @@ function InputField({
 
   return (
     <div className={styles.fieldGroup}>
-      <div className={`${styles.fieldRow} ${focused ? styles.fieldRowFocused : ""}`}>
+      <div className={styles.fieldRow}>
         <div className={styles.fieldDot} data-type={dot ?? "origin"} />
 
         <input
@@ -200,7 +198,6 @@ function InputField({
           placeholder={placeholder}
           value={value}
           autoComplete="off"
-          autoFocus={autoFocus}
           onFocus={() => setFocused(true)}
           onBlur={() => setTimeout(() => setFocused(false), 150)}
           onChange={(e) => onChange(e.target.value)}
@@ -267,23 +264,42 @@ function InputField({
 function RoutePills({ segments }: { segments: RouteSegment[] }): React.JSX.Element {
   return (
     <div className={styles.pills}>
-      {segments.map((seg, i) => (
-        <div key={i} className={styles.pill} data-type={seg.type}>
-          {seg.type === "walk" && <span>Walk</span>}
-          {seg.type === "bus" && seg.busLine && (
-            <span className={styles.pillLine}>Line {seg.busLine}</span>
-          )}
-          {seg.type === "transfer" && <span>Transfer</span>}
-          <span>{seg.duration}m</span>
-        </div>
-      ))}
+      {segments.map((seg, i) => {
+        if (seg.type === "walk") {
+          return (
+            <div key={i} className={styles.pillWalk}>
+              <Footprints size={12} aria-hidden="true" />
+              <span>{seg.duration} min</span>
+            </div>
+          );
+        }
+        if (seg.type === "bus" && seg.busLine) {
+          const bg = getLineBackgroundColor(seg.busLine, "string");
+          const fg = getLineTextColor(seg.busLine);
+          return (
+            <div key={i} className={styles.pillBus} style={{ background: bg, color: fg }}>
+              <Bus size={12} aria-hidden="true" />
+              <span>{seg.busLine}</span>
+              <span className={styles.pillBusDuration}>{seg.duration} min</span>
+            </div>
+          );
+        }
+        if (seg.type === "transfer") {
+          return (
+            <div key={i} className={styles.pillTransfer}>
+              <ArrowUpDown size={12} aria-hidden="true" />
+              <span>Transfer</span>
+            </div>
+          );
+        }
+        return null;
+      })}
     </div>
   );
 }
 
 interface RouteCardProps {
   route: RouteOption;
-  getText: (k: string) => string;
   onClick: () => void;
 }
 
@@ -295,14 +311,14 @@ function RouteCard({ route, onClick }: RouteCardProps): React.JSX.Element {
           <RoutePills segments={route.segments} />
           <div className={styles.routeCardTimes}>
             <span className={styles.routeDepTime}>{route.departure}</span>
-            <span className={styles.routeTimeSep}>→</span>
+            <ArrowRight size={14} className={styles.routeTimeSep} aria-hidden="true" />
             <span className={styles.routeArrTime}>{route.arrival}</span>
           </div>
         </div>
         <div className={styles.routeCardRight}>
           <div className={styles.routeDuration}>
             <Clock size={12} aria-hidden="true" />
-            <span>{route.totalMinutes}m</span>
+            <span>{route.totalMinutes} min</span>
           </div>
           <ChevronRight size={16} className={styles.routeChevron} aria-hidden="true" />
         </div>
@@ -317,30 +333,51 @@ interface StepRowProps {
 }
 
 function StepRow({ segment, isLast }: StepRowProps): React.JSX.Element {
+  const lineBg = segment.busLine ? getLineBackgroundColor(segment.busLine, "string") : "";
+  const lineFg = segment.busLine ? getLineTextColor(segment.busLine) : "";
+
   return (
     <div className={styles.step}>
       <div className={styles.stepTimeline}>
-        <div className={styles.stepDot} data-type={segment.type} />
+        <div
+          className={styles.stepDot}
+          style={
+            segment.type === "bus" && lineBg
+              ? { background: lineBg }
+              : undefined
+          }
+          data-type={segment.type}
+        />
         {!isLast && <div className={styles.stepLine} data-type={segment.type} />}
       </div>
+
       <div className={styles.stepBody}>
         {segment.type === "walk" && (
-          <div className={styles.stepCard} data-type="walk">
+          <div className={styles.stepCard}>
+            <div className={styles.stepCardAccent} data-type="walk" />
             <div className={styles.stepCardContent}>
-              <div className={styles.stepCardTitle}>
-                Walk{segment.distanceMeters ? ` ${segment.distanceMeters} m` : ""}
+              <div className={styles.stepWalkHeader}>
+                <Footprints size={15} className={styles.stepWalkIcon} aria-hidden="true" />
+                <span className={styles.stepCardTitle}>
+                  Walk{segment.distanceMeters ? ` · ${segment.distanceMeters} m` : ""}
+                </span>
               </div>
               <div className={styles.stepCardSub}>{segment.label}</div>
               <div className={styles.stepCardTime}>{segment.duration} minutes</div>
             </div>
           </div>
         )}
-        {segment.type === "bus" && (
-          <div className={styles.stepCard} data-type="bus">
+
+        {segment.type === "bus" && segment.busLine && (
+          <div className={styles.stepCard}>
+            <div
+              className={styles.stepCardBusHeader}
+              style={{ background: lineBg, color: lineFg }}
+            >
+              <Bus size={16} aria-hidden="true" />
+              <span className={styles.stepCardBusNumber}>{segment.busLine}</span>
+            </div>
             <div className={styles.stepCardContent}>
-              <div className={styles.stepCardTitleRow}>
-                <div className={styles.lineBadge}>Line {segment.busLine}</div>
-              </div>
               <div className={styles.stepCardSub}>
                 Board at <strong>{segment.fromStop}</strong>
               </div>
@@ -351,10 +388,15 @@ function StepRow({ segment, isLast }: StepRowProps): React.JSX.Element {
             </div>
           </div>
         )}
+
         {segment.type === "transfer" && (
-          <div className={styles.stepCard} data-type="transfer">
+          <div className={styles.stepCard}>
+            <div className={styles.stepCardAccent} data-type="transfer" />
             <div className={styles.stepCardContent}>
-              <div className={styles.stepCardTitle}>Transfer</div>
+              <div className={styles.stepWalkHeader}>
+                <ArrowUpDown size={15} className={styles.stepTransferIcon} aria-hidden="true" />
+                <span className={styles.stepCardTitle}>Transfer</span>
+              </div>
               <div className={styles.stepCardSub}>{segment.label}</div>
               <div className={styles.stepCardTime}>{segment.duration} minutes</div>
             </div>
@@ -407,9 +449,7 @@ function HomeTripSubview(): React.JSX.Element {
     else setToPreds([]);
   };
 
-  const resolvePlace = async (
-    pred: PlacePrediction
-  ): Promise<SelectedPlace | null> => {
+  const resolvePlace = async (pred: PlacePrediction): Promise<SelectedPlace | null> => {
     const coords = await getPlaceCoordinates(pred);
     if (!coords) return null;
     const nearest = findNearestStop(coords.lat, coords.lng, Stops);
@@ -465,28 +505,45 @@ function HomeTripSubview(): React.JSX.Element {
 
   const hasValidTrip = fromPlace !== null && toPlace !== null;
 
+  // ── Journey detail view ──────────────────────────────────────────────────
   if (selectedRoute) {
     return (
       <Fragment>
-        <Nav isHeader titleText={getText("trip")} />
+        <Nav
+          isHeader={false}
+          titleText={getText("trip")}
+          onBack={() => setSelectedRoute(null)}
+        />
         <div className={styles.detailContent}>
           <div className={styles.detailSummary}>
             <div className={styles.detailSummaryRow}>
               <div className={styles.detailTimes}>
                 <span className={styles.detailDep}>{selectedRoute.departure}</span>
-                <span className={styles.detailSep}>→</span>
+                <ArrowRight size={16} className={styles.detailSep} aria-hidden="true" />
                 <span className={styles.detailArr}>{selectedRoute.arrival}</span>
               </div>
               <div className={styles.detailDuration}>
                 <Clock size={13} aria-hidden="true" />
-                {selectedRoute.totalMinutes} minutes
+                {selectedRoute.totalMinutes} min
               </div>
             </div>
-            <div className={styles.detailRoute}>
-              <CircleDot size={13} className={styles.detailRouteIcon} aria-hidden="true" />
-              <span className={styles.detailFromName}>{fromPlace?.name}</span>
-              <Navigation2 size={13} className={styles.detailRouteIcon} aria-hidden="true" />
-              <span className={styles.detailToName}>{toPlace?.name}</span>
+
+            <div className={styles.detailPlaces}>
+              <div className={styles.detailPlaceRow}>
+                <div className={styles.detailDot} data-type="origin" />
+                <div className={styles.detailPlaceText}>
+                  <span className={styles.detailPlaceLabel}>From</span>
+                  <span className={styles.detailPlaceName}>{fromPlace?.name}</span>
+                </div>
+              </div>
+              <div className={styles.detailPlaceConnector} />
+              <div className={styles.detailPlaceRow}>
+                <div className={styles.detailDot} data-type="destination" />
+                <div className={styles.detailPlaceText}>
+                  <span className={styles.detailPlaceLabel}>To</span>
+                  <span className={styles.detailPlaceName}>{toPlace?.name}</span>
+                </div>
+              </div>
             </div>
           </div>
 
@@ -499,6 +556,7 @@ function HomeTripSubview(): React.JSX.Element {
               />
             ))}
             <div className={styles.arriveRow}>
+              <div className={styles.arriveDot} />
               <span className={styles.arriveLabel}>Arrive at {selectedRoute.arrival}</span>
             </div>
           </div>
@@ -507,51 +565,51 @@ function HomeTripSubview(): React.JSX.Element {
     );
   }
 
+  // ── Search + route list view ─────────────────────────────────────────────
   return (
     <Fragment>
       <Nav isHeader titleText={getText("trip")} />
-      <div className={styles.content}>
 
+      <div className={styles.stickySearch}>
         <div className={styles.searchCard}>
-          <div className={styles.searchFields}>
-            <InputField
-              placeholder={getText("from")}
-              value={fromText}
-              onChange={handleFromChange}
-              onClear={() => { setFromText(""); setFromPlace(null); setFromPreds([]); }}
-              predictions={fromPreds}
-              onSelect={(p) => void selectFrom(p)}
-              showLocation
-              onLocation={handleLocate}
-              isLocating={isLocating}
-              dot="origin"
-              autoFocus={false}
-            />
+          <InputField
+            placeholder={getText("from")}
+            value={fromText}
+            onChange={handleFromChange}
+            onClear={() => { setFromText(""); setFromPlace(null); setFromPreds([]); }}
+            predictions={fromPreds}
+            onSelect={(p) => void selectFrom(p)}
+            showLocation
+            onLocation={handleLocate}
+            isLocating={isLocating}
+            dot="origin"
+          />
 
-            <div className={styles.fieldsDivider}>
-              <div className={styles.dividerLine} />
-              <button
-                type="button"
-                className={styles.swapBtn}
-                onClick={swapPlaces}
-                aria-label="Swap"
-              >
-                <ArrowUpDown size={15} aria-hidden="true" />
-              </button>
-            </div>
-
-            <InputField
-              placeholder={getText("to")}
-              value={toText}
-              onChange={handleToChange}
-              onClear={() => { setToText(""); setToPlace(null); setToPreds([]); }}
-              predictions={toPreds}
-              onSelect={(p) => void selectTo(p)}
-              dot="destination"
-            />
+          <div className={styles.fieldsDivider}>
+            <div className={styles.dividerLine} />
+            <button
+              type="button"
+              className={styles.swapBtn}
+              onClick={swapPlaces}
+              aria-label="Swap"
+            >
+              <ArrowUpDown size={15} aria-hidden="true" />
+            </button>
           </div>
-        </div>
 
+          <InputField
+            placeholder={getText("to")}
+            value={toText}
+            onChange={handleToChange}
+            onClear={() => { setToText(""); setToPlace(null); setToPreds([]); }}
+            predictions={toPreds}
+            onSelect={(p) => void selectTo(p)}
+            dot="destination"
+          />
+        </div>
+      </div>
+
+      <div className={styles.content}>
         {locationError && (
           <div className={styles.errorBanner}>{locationError}</div>
         )}
@@ -572,7 +630,6 @@ function HomeTripSubview(): React.JSX.Element {
               <RouteCard
                 key={route.id}
                 route={route}
-                getText={getText}
                 onClick={() => setSelectedRoute(route)}
               />
             ))}

--- a/src/views/home/subviews/HomeTripSubview.tsx
+++ b/src/views/home/subviews/HomeTripSubview.tsx
@@ -1,0 +1,393 @@
+import React from "react";
+import type { FormEvent } from "react";
+import { Fragment, useState, useMemo } from "react";
+import { ArrowRightUp, MapPin, Search, Clock, Bus, AlertCircle } from "lucide-react";
+
+import { useI18n } from "../../../contexts/I18nContext";
+import Nav from "../../../components/Nav";
+import stopsJson from "../../../json/stops.min.json";
+import type { StopTuple, StopsData } from "../../../types/stops";
+import styles from "./HomeTripSubview.module.css";
+
+const Stops = stopsJson as unknown as StopsData;
+
+interface RouteSegment {
+  type: "walk" | "bus" | "transfer";
+  duration: number;
+  description: string;
+  busLine?: string;
+  fromStop?: string;
+  toStop?: string;
+}
+
+interface RouteOption {
+  id: string;
+  duration: number;
+  departureTime: string;
+  arrivalTime: string;
+  segments: RouteSegment[];
+  transfers: number;
+}
+
+function HomeTripSubview(): React.JSX.Element {
+  const { getText } = useI18n();
+  const [fromText, setFromText] = useState("");
+  const [toText, setToText] = useState("");
+  const [fromStopId, setFromStopId] = useState<number | null>(null);
+  const [toStopId, setToStopId] = useState<number | null>(null);
+  const [showFromResults, setShowFromResults] = useState(false);
+  const [showToResults, setShowToResults] = useState(false);
+  const [selectedRoute, setSelectedRoute] = useState<RouteOption | null>(null);
+
+  const fromResults = useMemo<StopTuple[]>(() => {
+    if (!showFromResults || fromText.length === 0) return [];
+    const list: StopTuple[] = [];
+
+    if (isNaN(Number(fromText))) {
+      for (const stopKey in Stops) {
+        const stop = Stops[stopKey];
+        const stopName = stop[3].toLowerCase();
+        const searchTerm = fromText.toLowerCase();
+
+        if (searchTerm.length < 4) {
+          if (stopName.substring(0, searchTerm.length) !== searchTerm) {
+            continue;
+          }
+        } else if (!stopName.includes(searchTerm)) {
+          continue;
+        }
+
+        list.push(stop);
+        if (list.length === 6) break;
+      }
+    } else if (fromText in Stops) {
+      list.push(Stops[fromText]);
+    }
+
+    return list;
+  }, [fromText, showFromResults]);
+
+  const toResults = useMemo<StopTuple[]>(() => {
+    if (!showToResults || toText.length === 0) return [];
+    const list: StopTuple[] = [];
+
+    if (isNaN(Number(toText))) {
+      for (const stopKey in Stops) {
+        const stop = Stops[stopKey];
+        const stopName = stop[3].toLowerCase();
+        const searchTerm = toText.toLowerCase();
+
+        if (searchTerm.length < 4) {
+          if (stopName.substring(0, searchTerm.length) !== searchTerm) {
+            continue;
+          }
+        } else if (!stopName.includes(searchTerm)) {
+          continue;
+        }
+
+        list.push(stop);
+        if (list.length === 6) break;
+      }
+    } else if (toText in Stops) {
+      list.push(Stops[toText]);
+    }
+
+    return list;
+  }, [toText, showToResults]);
+
+  const generateMockRoutes = (): RouteOption[] => {
+    if (!fromStopId || !toStopId) return [];
+
+    const baseTime = new Date();
+    baseTime.setMinutes(baseTime.getMinutes() + 5);
+
+    return [
+      {
+        id: "route-1",
+        duration: 25,
+        departureTime: `${String(baseTime.getHours()).padStart(2, "0")}:${String(baseTime.getMinutes()).padStart(2, "0")}`,
+        arrivalTime: `${String(baseTime.getHours()).padStart(2, "0")}:${String(baseTime.getMinutes() + 25).padStart(2, "0")}`,
+        transfers: 0,
+        segments: [
+          {
+            type: "walk",
+            duration: 3,
+            description: `Walk to bus stop`,
+          },
+          {
+            type: "bus",
+            duration: 22,
+            description: `Bus line 1`,
+            busLine: "1",
+            fromStop: Stops[fromStopId]?.[3] || "Stop",
+            toStop: Stops[toStopId]?.[3] || "Stop",
+          },
+        ],
+      },
+      {
+        id: "route-2",
+        duration: 35,
+        departureTime: `${String(baseTime.getHours()).padStart(2, "0")}:${String(baseTime.getMinutes() + 15).padStart(2, "0")}`,
+        arrivalTime: `${String(baseTime.getHours()).padStart(2, "0")}:${String(baseTime.getMinutes() + 50).padStart(2, "0")}`,
+        transfers: 1,
+        segments: [
+          {
+            type: "walk",
+            duration: 2,
+            description: `Walk to bus stop`,
+          },
+          {
+            type: "bus",
+            duration: 15,
+            description: `Bus line 5`,
+            busLine: "5",
+            fromStop: Stops[fromStopId]?.[3] || "Stop",
+            toStop: "Transfer point",
+          },
+          {
+            type: "transfer",
+            duration: 3,
+            description: `Transfer to bus line 8`,
+          },
+          {
+            type: "bus",
+            duration: 15,
+            description: `Bus line 8`,
+            busLine: "8",
+            fromStop: "Transfer point",
+            toStop: Stops[toStopId]?.[3] || "Stop",
+          },
+        ],
+      },
+    ];
+  };
+
+  const routes = useMemo(generateMockRoutes, [fromStopId, toStopId]);
+
+  const selectFromStop = (stopId: number): void => {
+    setFromStopId(stopId);
+    setFromText(Stops[stopId]?.[3] || "");
+    setShowFromResults(false);
+  };
+
+  const selectToStop = (stopId: number): void => {
+    setToStopId(stopId);
+    setToText(Stops[stopId]?.[3] || "");
+    setShowToResults(false);
+  };
+
+  const hasValidTrip = fromStopId !== null && toStopId !== null;
+
+  return (
+    <Fragment>
+      <Nav isHeader titleText={getText("trip")} />
+      <div className={styles.content}>
+        {!selectedRoute ? (
+          <>
+            <div className={styles.searchContainer}>
+              <div className={styles.inputGroup}>
+                <div className={styles.inputWrapper}>
+                  <MapPin size={14} className={styles.icon} aria-hidden="true" />
+                  <input
+                    className={styles.input}
+                    type="text"
+                    placeholder={getText("from")}
+                    aria-label={getText("from")}
+                    value={fromText}
+                    onInput={(e: FormEvent<HTMLInputElement>) => {
+                      setFromText(e.currentTarget.value);
+                      setShowFromResults(true);
+                    }}
+                    onFocus={() => setShowFromResults(true)}
+                  />
+                </div>
+
+                {fromResults.length > 0 && showFromResults && (
+                  <div className={styles.results}>
+                    {fromResults.map((result, i) => {
+                      const stopId = result[0];
+                      const stopName = result[3];
+
+                      return (
+                        <button
+                          type="button"
+                          className={styles.resultItem}
+                          key={i}
+                          onClick={() => selectFromStop(stopId)}
+                        >
+                          <Search size={14} className={styles.resultIcon} aria-hidden="true" />
+                          <span>{`${stopName} (${stopId})`}</span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+
+              <div className={styles.inputGroup}>
+                <div className={styles.inputWrapper}>
+                  <MapPin size={14} className={styles.icon} aria-hidden="true" />
+                  <input
+                    className={styles.input}
+                    type="text"
+                    placeholder={getText("to")}
+                    aria-label={getText("to")}
+                    value={toText}
+                    onInput={(e: FormEvent<HTMLInputElement>) => {
+                      setToText(e.currentTarget.value);
+                      setShowToResults(true);
+                    }}
+                    onFocus={() => setShowToResults(true)}
+                  />
+                </div>
+
+                {toResults.length > 0 && showToResults && (
+                  <div className={styles.results}>
+                    {toResults.map((result, i) => {
+                      const stopId = result[0];
+                      const stopName = result[3];
+
+                      return (
+                        <button
+                          type="button"
+                          className={styles.resultItem}
+                          key={i}
+                          onClick={() => selectToStop(stopId)}
+                        >
+                          <Search size={14} className={styles.resultIcon} aria-hidden="true" />
+                          <span>{`${stopName} (${stopId})`}</span>
+                        </button>
+                      );
+                    })}
+                  </div>
+                )}
+              </div>
+            </div>
+
+            {hasValidTrip && (
+              <div className={styles.routesContainer}>
+                {routes.length === 0 ? (
+                  <div className={styles.noResults}>
+                    <AlertCircle size={20} className={styles.noResultsIcon} aria-hidden="true" />
+                    <p>{getText("no_routes_found")}</p>
+                  </div>
+                ) : (
+                  routes.map((route) => (
+                    <div
+                      key={route.id}
+                      className={styles.routeCard}
+                      onClick={() => setSelectedRoute(route)}
+                    >
+                      <div className={styles.routeHeader}>
+                        <div className={styles.routeTime}>
+                          <div className={styles.departure}>{route.departureTime}</div>
+                          <div className={styles.durationBadge}>
+                            <Clock size={12} aria-hidden="true" />
+                            {route.duration} {getText("minutes")}
+                          </div>
+                          <div className={styles.arrival}>{route.arrivalTime}</div>
+                        </div>
+                        <ArrowRightUp size={16} className={styles.arrowIcon} aria-hidden="true" />
+                      </div>
+
+                      <div className={styles.routeDetails}>
+                        {route.transfers === 0 ? (
+                          <div className={styles.directRoute}>
+                            <Bus size={14} aria-hidden="true" />
+                            Direct route
+                          </div>
+                        ) : (
+                          <div className={styles.transferRoute}>
+                            <Bus size={14} aria-hidden="true" />
+                            {route.transfers} transfer{route.transfers > 1 ? "s" : ""}
+                          </div>
+                        )}
+                      </div>
+                    </div>
+                  ))
+                )}
+              </div>
+            )}
+
+            {!hasValidTrip && (
+              <div className={styles.emptyState}>
+                <Search size={32} className={styles.emptyIcon} aria-hidden="true" />
+                <p>{getText("plan_trip")}</p>
+              </div>
+            )}
+          </>
+        ) : (
+          <div className={styles.routeDetail}>
+            <button
+              type="button"
+              className={styles.backButton}
+              onClick={() => setSelectedRoute(null)}
+            >
+              ← {getText("back") || "Back"}
+            </button>
+
+            <div className={styles.routeDetailHeader}>
+              <div className={styles.routeTimeDetail}>
+                <div className={styles.departureDetail}>{selectedRoute.departureTime}</div>
+                <div className={styles.durationBadgeDetail}>
+                  <Clock size={14} aria-hidden="true" />
+                  {selectedRoute.duration} {getText("minutes")}
+                </div>
+                <div className={styles.arrivalDetail}>{selectedRoute.arrivalTime}</div>
+              </div>
+            </div>
+
+            <div className={styles.stepsContainer}>
+              {selectedRoute.segments.map((segment, idx) => (
+                <div key={idx} className={styles.stepCard}>
+                  <div className={styles.stepIcon}>
+                    {segment.type === "walk" && (
+                      <div className={styles.walkIcon}>🚶</div>
+                    )}
+                    {segment.type === "bus" && (
+                      <div className={styles.busIcon}>
+                        <Bus size={16} aria-hidden="true" />
+                      </div>
+                    )}
+                    {segment.type === "transfer" && (
+                      <div className={styles.transferIcon}>↔</div>
+                    )}
+                  </div>
+
+                  <div className={styles.stepContent}>
+                    <div className={styles.stepTitle}>
+                      {segment.type === "walk" && getText("walk")}
+                      {segment.type === "bus" && getText("bus")}
+                      {segment.type === "transfer" && getText("transfer")}
+                    </div>
+
+                    {segment.busLine && (
+                      <div className={styles.busLineBadge}>{segment.busLine}</div>
+                    )}
+
+                    <div className={styles.stepDescription}>
+                      {segment.description}
+                    </div>
+
+                    {segment.fromStop && segment.toStop && (
+                      <div className={styles.stopInfo}>
+                        <div className={styles.fromStop}>{segment.fromStop}</div>
+                        <div className={styles.toStop}>{segment.toStop}</div>
+                      </div>
+                    )}
+
+                    <div className={styles.stepDuration}>
+                      {segment.duration} {getText("minutes")}
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </Fragment>
+  );
+}
+
+export default HomeTripSubview;

--- a/src/views/home/subviews/HomeTripSubview.tsx
+++ b/src/views/home/subviews/HomeTripSubview.tsx
@@ -375,18 +375,17 @@ function StepRow({ segment, isLast }: StepRowProps): React.JSX.Element {
         {segment.type === "bus" && segment.busLine && (
           <div className={styles.stepCard}>
             <div
-              className={styles.stepCardBusHeader}
-              style={{ background: lineBg, color: lineFg }}
-            >
-              <Bus size={16} aria-hidden="true" />
-              <span className={styles.stepCardBusNumber}>{segment.busLine}</span>
-              {segment.busDestination && (
-                <span className={styles.stepCardBusDestination}>
-                  towards {segment.busDestination}
-                </span>
-              )}
-            </div>
+              className={styles.stepCardAccent}
+              data-type="bus"
+              style={{ background: lineBg }}
+            />
             <div className={styles.stepCardContent}>
+              <div className={styles.stepWalkHeader}>
+                <Bus size={15} style={{ color: lineBg }} aria-hidden="true" />
+                <span className={styles.stepCardTitle}>
+                  {segment.busLine}{segment.busDestination ? ` · towards ${segment.busDestination}` : ""}
+                </span>
+              </div>
               <div className={styles.stepCardSub}>
                 Board at <strong>{segment.fromStop}</strong>
               </div>

--- a/src/views/home/subviews/HomeTripSubview.tsx
+++ b/src/views/home/subviews/HomeTripSubview.tsx
@@ -1,388 +1,594 @@
 import React from "react";
-import type { FormEvent } from "react";
-import { Fragment, useState, useMemo } from "react";
-import { ChevronRight, MapPin, Search, Clock, Bus, AlertCircle } from "lucide-react";
+import { Fragment, useState, useMemo, useRef, useCallback } from "react";
+import {
+  LocateFixed,
+  Search,
+  X,
+  Clock,
+  Bus,
+  Footprints,
+  ArrowUpDown,
+  CircleDot,
+  Navigation2,
+  ChevronRight,
+} from "lucide-react";
 
 import { useI18n } from "../../../contexts/I18nContext";
 import Nav from "../../../components/Nav";
 import stopsJson from "../../../json/stops.min.json";
-import type { StopTuple, StopsData } from "../../../types/stops";
+import type { StopsData } from "../../../types/stops";
+import { getPlacePredictions, getPlaceCoordinates } from "../../../utils/PlacesUtils";
+import type { PlacePrediction } from "../../../utils/PlacesUtils";
+import { findNearestStop } from "../../../utils/StopUtils";
+import type { NearestStop } from "../../../utils/StopUtils";
 import styles from "./HomeTripSubview.module.css";
 
 const Stops = stopsJson as unknown as StopsData;
 
+interface SelectedPlace {
+  name: string;
+  lat: number;
+  lng: number;
+  nearest: NearestStop;
+}
+
 interface RouteSegment {
   type: "walk" | "bus" | "transfer";
   duration: number;
-  description: string;
+  label: string;
   busLine?: string;
   fromStop?: string;
   toStop?: string;
+  distanceMeters?: number;
 }
 
 interface RouteOption {
   id: string;
-  duration: number;
-  departureTime: string;
-  arrivalTime: string;
+  totalMinutes: number;
+  departure: string;
+  arrival: string;
   segments: RouteSegment[];
   transfers: number;
+  lines: string[];
+}
+
+function formatTime(date: Date): string {
+  return `${String(date.getHours()).padStart(2, "0")}:${String(date.getMinutes()).padStart(2, "0")}`;
+}
+
+function addMinutes(date: Date, minutes: number): Date {
+  return new Date(date.getTime() + minutes * 60000);
+}
+
+function buildRoutes(from: SelectedPlace, to: SelectedPlace): RouteOption[] {
+  const now = new Date();
+  const busSpeedMps = 5.5; // 20 km/h average urban bus
+  const fromToStopMeters = from.nearest.distanceMeters;
+  const toStopToDestMeters = to.nearest.distanceMeters;
+  const stopToStopMeters = Math.sqrt(
+    Math.pow((from.nearest.stop[1] - to.nearest.stop[1]) * 111000, 2) +
+      Math.pow((from.nearest.stop[2] - to.nearest.stop[2]) * 72000, 2)
+  );
+  const busDurationMin = Math.max(4, Math.ceil(stopToStopMeters / (busSpeedMps * 60)));
+  const walkToDep = from.nearest.walkingMinutes;
+  const walkToArr = to.nearest.walkingMinutes;
+
+  const dep1 = addMinutes(now, 3);
+  const total1 = walkToDep + busDurationMin + walkToArr;
+
+  const dep2 = addMinutes(now, 9);
+  const halfBus = Math.ceil(busDurationMin / 2);
+  const total2 = walkToDep + halfBus + 3 + halfBus + walkToArr;
+
+  return [
+    {
+      id: "r1",
+      totalMinutes: total1,
+      departure: formatTime(dep1),
+      arrival: formatTime(addMinutes(dep1, total1)),
+      transfers: 0,
+      lines: ["1"],
+      segments: [
+        {
+          type: "walk",
+          duration: walkToDep,
+          label: from.nearest.stop[3],
+          distanceMeters: Math.round(fromToStopMeters),
+        },
+        {
+          type: "bus",
+          duration: busDurationMin,
+          label: "Línea 1",
+          busLine: "1",
+          fromStop: from.nearest.stop[3],
+          toStop: to.nearest.stop[3],
+        },
+        {
+          type: "walk",
+          duration: walkToArr,
+          label: to.name,
+          distanceMeters: Math.round(toStopToDestMeters),
+        },
+      ],
+    },
+    {
+      id: "r2",
+      totalMinutes: total2,
+      departure: formatTime(dep2),
+      arrival: formatTime(addMinutes(dep2, total2)),
+      transfers: 1,
+      lines: ["3", "7"],
+      segments: [
+        {
+          type: "walk",
+          duration: walkToDep,
+          label: from.nearest.stop[3],
+          distanceMeters: Math.round(fromToStopMeters),
+        },
+        {
+          type: "bus",
+          duration: halfBus,
+          label: "Línea 3",
+          busLine: "3",
+          fromStop: from.nearest.stop[3],
+          toStop: "Jardines de Pereda",
+        },
+        {
+          type: "transfer",
+          duration: 3,
+          label: "Jardines de Pereda",
+        },
+        {
+          type: "bus",
+          duration: halfBus,
+          label: "Línea 7",
+          busLine: "7",
+          fromStop: "Jardines de Pereda",
+          toStop: to.nearest.stop[3],
+        },
+        {
+          type: "walk",
+          duration: walkToArr,
+          label: to.name,
+          distanceMeters: Math.round(toStopToDestMeters),
+        },
+      ],
+    },
+  ];
+}
+
+interface InputFieldProps {
+  placeholder: string;
+  value: string;
+  onChange: (v: string) => void;
+  onClear: () => void;
+  predictions: PlacePrediction[];
+  onSelect: (p: PlacePrediction) => void;
+  showLocation?: boolean;
+  onLocation?: () => void;
+  isLocating?: boolean;
+  dot?: "origin" | "destination";
+  autoFocus?: boolean;
+}
+
+function InputField({
+  placeholder,
+  value,
+  onChange,
+  onClear,
+  predictions,
+  onSelect,
+  showLocation,
+  onLocation,
+  isLocating,
+  dot,
+  autoFocus,
+}: InputFieldProps): React.JSX.Element {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [focused, setFocused] = useState(false);
+  const showDropdown = focused && predictions.length > 0;
+
+  return (
+    <div className={styles.fieldGroup}>
+      <div className={`${styles.fieldRow} ${focused ? styles.fieldRowFocused : ""}`}>
+        <div className={styles.fieldDot} data-type={dot ?? "origin"} />
+
+        <input
+          ref={inputRef}
+          className={styles.fieldInput}
+          type="text"
+          placeholder={placeholder}
+          value={value}
+          autoComplete="off"
+          autoFocus={autoFocus}
+          onFocus={() => setFocused(true)}
+          onBlur={() => setTimeout(() => setFocused(false), 150)}
+          onChange={(e) => onChange(e.target.value)}
+        />
+
+        <div className={styles.fieldActions}>
+          {value.length > 0 && (
+            <button
+              type="button"
+              className={styles.clearBtn}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                onClear();
+                inputRef.current?.focus();
+              }}
+              aria-label="Clear"
+            >
+              <X size={14} aria-hidden="true" />
+            </button>
+          )}
+          {showLocation && (
+            <button
+              type="button"
+              className={`${styles.locateBtn} ${isLocating ? styles.locateBtnActive : ""}`}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                onLocation?.();
+              }}
+              aria-label="Use current location"
+            >
+              <LocateFixed size={16} aria-hidden="true" />
+            </button>
+          )}
+        </div>
+      </div>
+
+      {showDropdown && (
+        <div className={styles.dropdown}>
+          {predictions.map((p) => (
+            <button
+              key={p.placeId}
+              type="button"
+              className={styles.dropdownItem}
+              onMouseDown={(e) => {
+                e.preventDefault();
+                onSelect(p);
+              }}
+            >
+              <Search size={13} className={styles.dropdownIcon} aria-hidden="true" />
+              <div className={styles.dropdownText}>
+                <span className={styles.dropdownMain}>{p.mainText}</span>
+                {p.secondaryText && (
+                  <span className={styles.dropdownSub}>{p.secondaryText}</span>
+                )}
+              </div>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function RoutePills({ segments }: { segments: RouteSegment[] }): React.JSX.Element {
+  return (
+    <div className={styles.pills}>
+      {segments.map((seg, i) => (
+        <div key={i} className={styles.pill} data-type={seg.type}>
+          {seg.type === "walk" && <Footprints size={11} aria-hidden="true" />}
+          {seg.type === "bus" && seg.busLine && (
+            <span className={styles.pillLine}>{seg.busLine}</span>
+          )}
+          {seg.type === "transfer" && <ArrowUpDown size={11} aria-hidden="true" />}
+          <span>{seg.duration}′</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+interface RouteCardProps {
+  route: RouteOption;
+  getText: (k: string) => string;
+  onClick: () => void;
+}
+
+function RouteCard({ route, onClick }: RouteCardProps): React.JSX.Element {
+  return (
+    <button type="button" className={styles.routeCard} onClick={onClick}>
+      <div className={styles.routeCardInner}>
+        <div className={styles.routeCardLeft}>
+          <RoutePills segments={route.segments} />
+          <div className={styles.routeCardTimes}>
+            <span className={styles.routeDepTime}>{route.departure}</span>
+            <span className={styles.routeTimeSep}>→</span>
+            <span className={styles.routeArrTime}>{route.arrival}</span>
+          </div>
+        </div>
+        <div className={styles.routeCardRight}>
+          <div className={styles.routeDuration}>
+            <Clock size={12} aria-hidden="true" />
+            <span>{route.totalMinutes}′</span>
+          </div>
+          <ChevronRight size={16} className={styles.routeChevron} aria-hidden="true" />
+        </div>
+      </div>
+    </button>
+  );
+}
+
+interface StepRowProps {
+  segment: RouteSegment;
+  isLast: boolean;
+}
+
+function StepRow({ segment, isLast }: StepRowProps): React.JSX.Element {
+  return (
+    <div className={styles.step}>
+      <div className={styles.stepTimeline}>
+        <div className={styles.stepDot} data-type={segment.type} />
+        {!isLast && <div className={styles.stepLine} data-type={segment.type} />}
+      </div>
+      <div className={styles.stepBody}>
+        {segment.type === "walk" && (
+          <div className={styles.stepCard} data-type="walk">
+            <div className={styles.stepCardIcon} data-type="walk">
+              <Footprints size={15} aria-hidden="true" />
+            </div>
+            <div className={styles.stepCardContent}>
+              <div className={styles.stepCardTitle}>
+                Caminar{segment.distanceMeters ? ` ${segment.distanceMeters} m` : ""}
+              </div>
+              <div className={styles.stepCardSub}>{segment.label}</div>
+              <div className={styles.stepCardTime}>{segment.duration} min</div>
+            </div>
+          </div>
+        )}
+        {segment.type === "bus" && (
+          <div className={styles.stepCard} data-type="bus">
+            <div className={styles.stepCardIcon} data-type="bus">
+              <Bus size={15} aria-hidden="true" />
+            </div>
+            <div className={styles.stepCardContent}>
+              <div className={styles.stepCardTitleRow}>
+                <div className={styles.lineBadge}>{segment.busLine}</div>
+                <div className={styles.stepCardTitle}>{segment.label}</div>
+              </div>
+              <div className={styles.stepCardSub}>
+                Subir en <strong>{segment.fromStop}</strong>
+              </div>
+              <div className={styles.stepCardSub}>
+                Bajar en <strong>{segment.toStop}</strong>
+              </div>
+              <div className={styles.stepCardTime}>{segment.duration} min</div>
+            </div>
+          </div>
+        )}
+        {segment.type === "transfer" && (
+          <div className={styles.stepCard} data-type="transfer">
+            <div className={styles.stepCardIcon} data-type="transfer">
+              <ArrowUpDown size={15} aria-hidden="true" />
+            </div>
+            <div className={styles.stepCardContent}>
+              <div className={styles.stepCardTitle}>Transbordo</div>
+              <div className={styles.stepCardSub}>{segment.label}</div>
+              <div className={styles.stepCardTime}>{segment.duration} min</div>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
 }
 
 function HomeTripSubview(): React.JSX.Element {
   const { getText } = useI18n();
+
   const [fromText, setFromText] = useState("");
   const [toText, setToText] = useState("");
-  const [fromStopId, setFromStopId] = useState<number | null>(null);
-  const [toStopId, setToStopId] = useState<number | null>(null);
-  const [showFromResults, setShowFromResults] = useState(false);
-  const [showToResults, setShowToResults] = useState(false);
+  const [fromPreds, setFromPreds] = useState<PlacePrediction[]>([]);
+  const [toPreds, setToPreds] = useState<PlacePrediction[]>([]);
+  const [fromPlace, setFromPlace] = useState<SelectedPlace | null>(null);
+  const [toPlace, setToPlace] = useState<SelectedPlace | null>(null);
+  const [isLocating, setIsLocating] = useState(false);
+  const [locationError, setLocationError] = useState<string | null>(null);
   const [selectedRoute, setSelectedRoute] = useState<RouteOption | null>(null);
 
-  const fromResults = useMemo<StopTuple[]>(() => {
-    if (!showFromResults || fromText.length === 0) return [];
-    const list: StopTuple[] = [];
+  const routes = useMemo<RouteOption[]>(() => {
+    if (!fromPlace || !toPlace) return [];
+    return buildRoutes(fromPlace, toPlace);
+  }, [fromPlace, toPlace]);
 
-    if (isNaN(Number(fromText))) {
-      for (const stopKey in Stops) {
-        const stop = Stops[stopKey];
-        const stopName = stop[3].toLowerCase();
-        const searchTerm = fromText.toLowerCase();
+  const fetchFromPreds = useCallback(async (value: string) => {
+    const preds = await getPlacePredictions(value);
+    setFromPreds(preds);
+  }, []);
 
-        if (searchTerm.length < 4) {
-          if (stopName.substring(0, searchTerm.length) !== searchTerm) {
-            continue;
-          }
-        } else if (!stopName.includes(searchTerm)) {
-          continue;
-        }
+  const fetchToPreds = useCallback(async (value: string) => {
+    const preds = await getPlacePredictions(value);
+    setToPreds(preds);
+  }, []);
 
-        list.push(stop);
-        if (list.length === 6) break;
-      }
-    } else if (fromText in Stops) {
-      list.push(Stops[fromText]);
+  const handleFromChange = (v: string): void => {
+    setFromText(v);
+    setFromPlace(null);
+    if (v.length > 1) void fetchFromPreds(v);
+    else setFromPreds([]);
+  };
+
+  const handleToChange = (v: string): void => {
+    setToText(v);
+    setToPlace(null);
+    if (v.length > 1) void fetchToPreds(v);
+    else setToPreds([]);
+  };
+
+  const resolvePlace = async (
+    pred: PlacePrediction
+  ): Promise<SelectedPlace | null> => {
+    const coords = await getPlaceCoordinates(pred.placeId);
+    if (!coords) return null;
+    const nearest = findNearestStop(coords.lat, coords.lng, Stops);
+    return { name: pred.mainText, lat: coords.lat, lng: coords.lng, nearest };
+  };
+
+  const selectFrom = async (pred: PlacePrediction): Promise<void> => {
+    setFromText(pred.mainText);
+    setFromPreds([]);
+    const place = await resolvePlace(pred);
+    if (place) setFromPlace(place);
+  };
+
+  const selectTo = async (pred: PlacePrediction): Promise<void> => {
+    setToText(pred.mainText);
+    setToPreds([]);
+    const place = await resolvePlace(pred);
+    if (place) setToPlace(place);
+  };
+
+  const handleLocate = (): void => {
+    if (!navigator.geolocation) {
+      setLocationError(getText("location_not_available"));
+      return;
     }
-
-    return list;
-  }, [fromText, showFromResults]);
-
-  const toResults = useMemo<StopTuple[]>(() => {
-    if (!showToResults || toText.length === 0) return [];
-    const list: StopTuple[] = [];
-
-    if (isNaN(Number(toText))) {
-      for (const stopKey in Stops) {
-        const stop = Stops[stopKey];
-        const stopName = stop[3].toLowerCase();
-        const searchTerm = toText.toLowerCase();
-
-        if (searchTerm.length < 4) {
-          if (stopName.substring(0, searchTerm.length) !== searchTerm) {
-            continue;
-          }
-        } else if (!stopName.includes(searchTerm)) {
-          continue;
-        }
-
-        list.push(stop);
-        if (list.length === 6) break;
-      }
-    } else if (toText in Stops) {
-      list.push(Stops[toText]);
-    }
-
-    return list;
-  }, [toText, showToResults]);
-
-  const generateMockRoutes = (): RouteOption[] => {
-    if (!fromStopId || !toStopId) return [];
-
-    const baseTime = new Date();
-    baseTime.setMinutes(baseTime.getMinutes() + 5);
-
-    return [
-      {
-        id: "route-1",
-        duration: 25,
-        departureTime: `${String(baseTime.getHours()).padStart(2, "0")}:${String(baseTime.getMinutes()).padStart(2, "0")}`,
-        arrivalTime: `${String(baseTime.getHours()).padStart(2, "0")}:${String(baseTime.getMinutes() + 25).padStart(2, "0")}`,
-        transfers: 0,
-        segments: [
-          {
-            type: "walk",
-            duration: 3,
-            description: `Walk to bus stop`,
-          },
-          {
-            type: "bus",
-            duration: 22,
-            description: `Bus line 1`,
-            busLine: "1",
-            fromStop: Stops[fromStopId]?.[3] || "Stop",
-            toStop: Stops[toStopId]?.[3] || "Stop",
-          },
-        ],
+    setIsLocating(true);
+    setLocationError(null);
+    navigator.geolocation.getCurrentPosition(
+      (pos) => {
+        const { latitude: lat, longitude: lng } = pos.coords;
+        const nearest = findNearestStop(lat, lng, Stops);
+        setFromText(getText("current_location"));
+        setFromPlace({ name: getText("current_location"), lat, lng, nearest });
+        setFromPreds([]);
+        setIsLocating(false);
       },
-      {
-        id: "route-2",
-        duration: 35,
-        departureTime: `${String(baseTime.getHours()).padStart(2, "0")}:${String(baseTime.getMinutes() + 15).padStart(2, "0")}`,
-        arrivalTime: `${String(baseTime.getHours()).padStart(2, "0")}:${String(baseTime.getMinutes() + 50).padStart(2, "0")}`,
-        transfers: 1,
-        segments: [
-          {
-            type: "walk",
-            duration: 2,
-            description: `Walk to bus stop`,
-          },
-          {
-            type: "bus",
-            duration: 15,
-            description: `Bus line 5`,
-            busLine: "5",
-            fromStop: Stops[fromStopId]?.[3] || "Stop",
-            toStop: "Transfer point",
-          },
-          {
-            type: "transfer",
-            duration: 3,
-            description: `Transfer to bus line 8`,
-          },
-          {
-            type: "bus",
-            duration: 15,
-            description: `Bus line 8`,
-            busLine: "8",
-            fromStop: "Transfer point",
-            toStop: Stops[toStopId]?.[3] || "Stop",
-          },
-        ],
+      () => {
+        setLocationError(getText("location_not_available"));
+        setIsLocating(false);
       },
-    ];
+      { timeout: 10000 }
+    );
   };
 
-  const routes = useMemo(generateMockRoutes, [fromStopId, toStopId]);
-
-  const selectFromStop = (stopId: number): void => {
-    setFromStopId(stopId);
-    setFromText(Stops[stopId]?.[3] || "");
-    setShowFromResults(false);
+  const swapPlaces = (): void => {
+    setFromText(toText);
+    setToText(fromText);
+    setFromPlace(toPlace);
+    setToPlace(fromPlace);
+    setFromPreds([]);
+    setToPreds([]);
   };
 
-  const selectToStop = (stopId: number): void => {
-    setToStopId(stopId);
-    setToText(Stops[stopId]?.[3] || "");
-    setShowToResults(false);
-  };
+  const hasValidTrip = fromPlace !== null && toPlace !== null;
 
-  const hasValidTrip = fromStopId !== null && toStopId !== null;
+  if (selectedRoute) {
+    return (
+      <Fragment>
+        <Nav isHeader={false} titleText={`${selectedRoute.departure} → ${selectedRoute.arrival}`} />
+        <div className={styles.detailContent}>
+          <div className={styles.detailSummary}>
+            <div className={styles.detailSummaryRow}>
+              <div className={styles.detailTimes}>
+                <span className={styles.detailDep}>{selectedRoute.departure}</span>
+                <span className={styles.detailSep}>→</span>
+                <span className={styles.detailArr}>{selectedRoute.arrival}</span>
+              </div>
+              <div className={styles.detailDuration}>
+                <Clock size={13} aria-hidden="true" />
+                {selectedRoute.totalMinutes} min
+              </div>
+            </div>
+            <div className={styles.detailRoute}>
+              <CircleDot size={13} className={styles.detailRouteIcon} aria-hidden="true" />
+              <span className={styles.detailFromName}>{fromPlace?.name}</span>
+              <Navigation2 size={13} className={styles.detailRouteIcon} aria-hidden="true" />
+              <span className={styles.detailToName}>{toPlace?.name}</span>
+            </div>
+          </div>
+
+          <div className={styles.stepsContainer}>
+            {selectedRoute.segments.map((seg, i) => (
+              <StepRow
+                key={i}
+                segment={seg}
+                isLast={i === selectedRoute.segments.length - 1}
+              />
+            ))}
+            <div className={styles.arriveRow}>
+              <div className={styles.arriveIcon}>
+                <Navigation2 size={14} aria-hidden="true" />
+              </div>
+              <span className={styles.arriveLabel}>{getText("arrival")}: {selectedRoute.arrival}</span>
+            </div>
+          </div>
+        </div>
+      </Fragment>
+    );
+  }
 
   return (
     <Fragment>
       <Nav isHeader titleText={getText("trip")} />
       <div className={styles.content}>
-        {!selectedRoute ? (
-          <>
-            <div className={styles.searchContainer}>
-              <div className={styles.inputGroup}>
-                <div className={styles.inputWrapper}>
-                  <MapPin size={14} className={styles.icon} aria-hidden="true" />
-                  <input
-                    className={styles.input}
-                    type="text"
-                    placeholder={getText("from")}
-                    aria-label={getText("from")}
-                    value={fromText}
-                    onInput={(e: FormEvent<HTMLInputElement>) => {
-                      setFromText(e.currentTarget.value);
-                      setShowFromResults(true);
-                    }}
-                    onFocus={() => setShowFromResults(true)}
-                  />
-                </div>
 
-                {fromResults.length > 0 && showFromResults && (
-                  <div className={styles.results}>
-                    {fromResults.map((result, i) => {
-                      const stopId = result[0];
-                      const stopName = result[3];
+        <div className={styles.searchCard}>
+          <div className={styles.searchFields}>
+            <InputField
+              placeholder={getText("from")}
+              value={fromText}
+              onChange={handleFromChange}
+              onClear={() => { setFromText(""); setFromPlace(null); setFromPreds([]); }}
+              predictions={fromPreds}
+              onSelect={(p) => void selectFrom(p)}
+              showLocation
+              onLocation={handleLocate}
+              isLocating={isLocating}
+              dot="origin"
+              autoFocus={false}
+            />
 
-                      return (
-                        <button
-                          type="button"
-                          className={styles.resultItem}
-                          key={i}
-                          onClick={() => selectFromStop(stopId)}
-                        >
-                          <Search size={14} className={styles.resultIcon} aria-hidden="true" />
-                          <span>{`${stopName} (${stopId})`}</span>
-                        </button>
-                      );
-                    })}
-                  </div>
-                )}
-              </div>
-
-              <div className={styles.inputGroup}>
-                <div className={styles.inputWrapper}>
-                  <MapPin size={14} className={styles.icon} aria-hidden="true" />
-                  <input
-                    className={styles.input}
-                    type="text"
-                    placeholder={getText("to")}
-                    aria-label={getText("to")}
-                    value={toText}
-                    onInput={(e: FormEvent<HTMLInputElement>) => {
-                      setToText(e.currentTarget.value);
-                      setShowToResults(true);
-                    }}
-                    onFocus={() => setShowToResults(true)}
-                  />
-                </div>
-
-                {toResults.length > 0 && showToResults && (
-                  <div className={styles.results}>
-                    {toResults.map((result, i) => {
-                      const stopId = result[0];
-                      const stopName = result[3];
-
-                      return (
-                        <button
-                          type="button"
-                          className={styles.resultItem}
-                          key={i}
-                          onClick={() => selectToStop(stopId)}
-                        >
-                          <Search size={14} className={styles.resultIcon} aria-hidden="true" />
-                          <span>{`${stopName} (${stopId})`}</span>
-                        </button>
-                      );
-                    })}
-                  </div>
-                )}
-              </div>
+            <div className={styles.fieldsDivider}>
+              <div className={styles.dividerLine} />
+              <button
+                type="button"
+                className={styles.swapBtn}
+                onClick={swapPlaces}
+                aria-label="Swap"
+              >
+                <ArrowUpDown size={15} aria-hidden="true" />
+              </button>
             </div>
 
-            {hasValidTrip && (
-              <div className={styles.routesContainer}>
-                {routes.length === 0 ? (
-                  <div className={styles.noResults}>
-                    <AlertCircle size={20} className={styles.noResultsIcon} aria-hidden="true" />
-                    <p>{getText("no_routes_found")}</p>
-                  </div>
-                ) : (
-                  routes.map((route) => (
-                    <div
-                      key={route.id}
-                      className={styles.routeCard}
-                      onClick={() => setSelectedRoute(route)}
-                    >
-                      <div className={styles.routeHeader}>
-                        <div className={styles.routeTime}>
-                          <div className={styles.departure}>{route.departureTime}</div>
-                          <div className={styles.durationBadge}>
-                            <Clock size={12} aria-hidden="true" />
-                            {route.duration} {getText("minutes")}
-                          </div>
-                          <div className={styles.arrival}>{route.arrivalTime}</div>
-                        </div>
-                        <ChevronRight size={16} className={styles.arrowIcon} aria-hidden="true" />
-                      </div>
+            <InputField
+              placeholder={getText("to")}
+              value={toText}
+              onChange={handleToChange}
+              onClear={() => { setToText(""); setToPlace(null); setToPreds([]); }}
+              predictions={toPreds}
+              onSelect={(p) => void selectTo(p)}
+              dot="destination"
+            />
+          </div>
+        </div>
 
-                      <div className={styles.routeDetails}>
-                        {route.transfers === 0 ? (
-                          <div className={styles.directRoute}>
-                            <Bus size={14} aria-hidden="true" />
-                            Direct route
-                          </div>
-                        ) : (
-                          <div className={styles.transferRoute}>
-                            <Bus size={14} aria-hidden="true" />
-                            {route.transfers} transfer{route.transfers > 1 ? "s" : ""}
-                          </div>
-                        )}
-                      </div>
-                    </div>
-                  ))
-                )}
-              </div>
-            )}
+        {locationError && (
+          <div className={styles.errorBanner}>{locationError}</div>
+        )}
 
-            {!hasValidTrip && (
-              <div className={styles.emptyState}>
-                <Search size={32} className={styles.emptyIcon} aria-hidden="true" />
-                <p>{getText("plan_trip")}</p>
-              </div>
-            )}
-          </>
-        ) : (
-          <div className={styles.routeDetail}>
-            <button
-              type="button"
-              className={styles.backButton}
-              onClick={() => setSelectedRoute(null)}
-            >
-              ← {getText("back") || "Back"}
-            </button>
+        {!hasValidTrip && !fromText && !toText && (
+          <div className={styles.emptyState}>
+            <Bus size={36} className={styles.emptyIcon} aria-hidden="true" />
+            <p className={styles.emptyTitle}>{getText("plan_trip")}</p>
+            <p className={styles.emptyHint}>
+              {getText("from")} · {getText("to")}
+            </p>
+          </div>
+        )}
 
-            <div className={styles.routeDetailHeader}>
-              <div className={styles.routeTimeDetail}>
-                <div className={styles.departureDetail}>{selectedRoute.departureTime}</div>
-                <div className={styles.durationBadgeDetail}>
-                  <Clock size={14} aria-hidden="true" />
-                  {selectedRoute.duration} {getText("minutes")}
-                </div>
-                <div className={styles.arrivalDetail}>{selectedRoute.arrivalTime}</div>
-              </div>
-            </div>
-
-            <div className={styles.stepsContainer}>
-              {selectedRoute.segments.map((segment, idx) => (
-                <div key={idx} className={styles.stepCard}>
-                  <div className={styles.stepIcon}>
-                    {segment.type === "walk" && (
-                      <div className={styles.walkIcon}>🚶</div>
-                    )}
-                    {segment.type === "bus" && (
-                      <div className={styles.busIcon}>
-                        <Bus size={16} aria-hidden="true" />
-                      </div>
-                    )}
-                    {segment.type === "transfer" && (
-                      <div className={styles.transferIcon}>↔</div>
-                    )}
-                  </div>
-
-                  <div className={styles.stepContent}>
-                    <div className={styles.stepTitle}>
-                      {segment.type === "walk" && getText("walk")}
-                      {segment.type === "bus" && getText("bus")}
-                      {segment.type === "transfer" && getText("transfer")}
-                    </div>
-
-                    {segment.busLine && (
-                      <div className={styles.busLineBadge}>{segment.busLine}</div>
-                    )}
-
-                    <div className={styles.stepDescription}>
-                      {segment.description}
-                    </div>
-
-                    {segment.fromStop && segment.toStop && (
-                      <div className={styles.stopInfo}>
-                        <div className={styles.fromStop}>{segment.fromStop}</div>
-                        <div className={styles.toStop}>{segment.toStop}</div>
-                      </div>
-                    )}
-
-                    <div className={styles.stepDuration}>
-                      {segment.duration} {getText("minutes")}
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
+        {hasValidTrip && (
+          <div className={styles.routesList}>
+            {routes.map((route) => (
+              <RouteCard
+                key={route.id}
+                route={route}
+                getText={getText}
+                onClick={() => setSelectedRoute(route)}
+              />
+            ))}
           </div>
         )}
       </div>


### PR DESCRIPTION
- Add new SUB_VIEW_ID_TRIP subview type to support trip planning
- Create HomeTripSubview component with Apple Maps-inspired design
- Implement route search with from/to stop selection
- Display route options with departure/arrival times and durations
- Show step-by-step directions (walk, bus, transfer segments)
- Add Trip tab to navigation menu with Navigation icon
- Update all language files (8 languages) with trip-related translations
- Apply modern iOS-style UI with cards, smooth interactions, and dark mode support

https://claude.ai/code/session_01P43mFmYUSceiQfU5hiQoAJ