### PR TITLE
Redesign trip UI with light blue backgrounds and compact layout

### DIFF
--- a/src/views/home/subviews/HomeTripSubview.module.css
+++ b/src/views/home/subviews/HomeTripSubview.module.css
@@ -313,17 +313,15 @@
   display: block;
   width: 100%;
   text-align: left;
-  background: #fff;
+  background: rgba(0, 112, 240, 0.1);
   border-radius: 16px;
   padding: 16px;
   transition: transform 0.15s;
-  box-shadow: 0 1px 6px rgba(0, 0, 0, 0.07);
 
   &:active { transform: scale(0.98); }
 
   @media (prefers-color-scheme: dark) {
-    background: #1c1b20;
-    box-shadow: none;
+    background: rgba(0, 112, 240, 0.08);
   }
 }
 
@@ -374,15 +372,15 @@
   flex-direction: column;
   align-items: center;
   justify-content: center;
-  background: rgba(0, 112, 240, 0.1);
+  background: transparent;
   border-radius: 14px;
-  padding: 12px 14px;
-  gap: 4px;
+  padding: 4px;
+  gap: 0;
   flex-shrink: 0;
-  min-width: 58px;
+  min-width: auto;
 
   @media (prefers-color-scheme: dark) {
-    background: rgba(0, 112, 240, 0.18);
+    background: transparent;
   }
 }
 
@@ -391,21 +389,12 @@
 }
 
 .stepsBtnLabel {
-  font-size: 12px;
-  font-weight: 600;
-  color: var(--color-blue);
+  display: none;
 }
 
 /* ── Detail summary ── */
 .detailSummary {
-  background: #f2f2f7;
-  border-radius: 14px;
-  padding: 14px 16px;
-  margin-bottom: 16px;
-
-  @media (prefers-color-scheme: dark) {
-    background: #1c1b20;
-  }
+  display: none;
 }
 
 .detailSummaryRow {
@@ -524,6 +513,7 @@
   align-items: center;
   width: 32px;
   flex-shrink: 0;
+  padding-bottom: 12px;
 }
 
 .stepDot {
@@ -531,7 +521,7 @@
   height: 12px;
   border-radius: 50%;
   flex-shrink: 0;
-  margin-top: 14px;
+  margin-top: 8px;
   z-index: 1;
 
   &[data-type="walk"] { background: #aeaeb2; }
@@ -542,8 +532,8 @@
 .stepLine {
   width: 2px;
   flex: 1;
-  min-height: 16px;
-  margin: 2px 0;
+  min-height: 20px;
+  margin: 4px 0;
 
   &[data-type="walk"] {
     background-image: repeating-linear-gradient(

--- a/src/views/home/subviews/HomeTripSubview.tsx
+++ b/src/views/home/subviews/HomeTripSubview.tsx
@@ -560,41 +560,10 @@ function HomeTripSubview(): React.JSX.Element {
       <Fragment>
         <Nav
           isHeader={false}
-          titleText={getText("trip")}
+          titleText={toPlace?.name || getText("trip")}
           onBack={() => setSelectedRoute(null)}
         />
         <div className={styles.detailContent}>
-          <div className={styles.detailSummary}>
-            <div className={styles.detailSummaryRow}>
-              <div className={styles.detailTimes}>
-                <span className={styles.detailDep}>{selectedRoute.departure}</span>
-                <ArrowRight size={16} className={styles.detailSep} aria-hidden="true" />
-                <span className={styles.detailArr}>{selectedRoute.arrival}</span>
-              </div>
-              <div className={styles.detailDuration}>
-                <Clock size={13} aria-hidden="true" />
-                {selectedRoute.totalMinutes} min
-              </div>
-            </div>
-
-            <div className={styles.detailPlaces}>
-              <div className={styles.detailPlaceRow}>
-                <div className={styles.detailDot} data-type="origin" />
-                <div className={styles.detailPlaceText}>
-                  <span className={styles.detailPlaceLabel}>From</span>
-                  <span className={styles.detailPlaceName}>{fromPlace?.name}</span>
-                </div>
-              </div>
-              <div className={styles.detailPlaceConnector} />
-              <div className={styles.detailPlaceRow}>
-                <div className={styles.detailDot} data-type="destination" />
-                <div className={styles.detailPlaceText}>
-                  <span className={styles.detailPlaceLabel}>To</span>
-                  <span className={styles.detailPlaceName}>{toPlace?.name}</span>
-                </div>
-              </div>
-            </div>
-          </div>
 
           <div className={styles.stepsContainer}>
             {selectedRoute.segments.map((seg, i) => (


### PR DESCRIPTION
- Remove shadows from route cards
- Apply light blue background (rgba(0, 112, 240, 0.1)) to route options matching home menu style
- Make Steps button compact with icon only (hide text label)
- Remove trip summary section from detail view
- Update header to show destination name instead of 'Trip'
- Fix timeline dots and lines alignment for better visual spacing

https://claude.ai/code/session_01RSheij7sqPnEqC8crki3sm